### PR TITLE
POC of Config/serialization.

### DIFF
--- a/src/dimcat/config.py
+++ b/src/dimcat/config.py
@@ -1,0 +1,42 @@
+from typing import TYPE_CHECKING
+
+import marshmallow as mm
+
+# To avoid circular import.
+if TYPE_CHECKING:
+    from dimcat.base import DimcatObject
+
+_CONFIGURED_REGISTRY = {}
+
+
+class DimCatConfig(mm.Schema):
+    """
+    The base class of the config system of Dimcat, with which to define custom configs. This class holds the logic for
+    serializing/deserializing config objects.
+    """
+
+    # Contains the configured class. This class is returned when loading a config object.
+    # This should be overridden by every subclass.
+    configured_object: "DimcatObject" = None
+    # This is used internally by marshmallow to deserialize the configured object.
+    # Note that this field added "manually" by add_class_builder_to_json, for practical reasons.
+    _configured_type = mm.fields.Function(deserialize=lambda v : _CONFIGURED_REGISTRY[v])
+
+    def __new__(cls, *args, **kwargs):
+        # Register a new class builder to the _CLASS_BUILDERS registry. Is used to serialize/deserialize dim cats objects
+        # configured.
+        if cls.configured_object is None:
+            raise ValueError(f"{cls} object does not have configured_object attribute !")
+        _CONFIGURED_REGISTRY[cls.configured_object.__qualname__] = cls.configured_object
+        return object.__new__(cls)
+
+    @mm.post_dump
+    def add_class_builder_to_json(self, data, **kwargs):
+        # Add the field containing the configured object class, that will be used a class builder upon deserializing.
+        data["_configured_type"] = self.configured_object.__qualname__
+        return data
+
+    @classmethod
+    def from_json(cls, json) -> dict:
+        # Instantiating cls() everytime is is quite ugly. There is likely a better solution
+        return cls().loads(json)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+from pprint import pprint
+
+import pytest
+from dimcat.config import DimCatConfig
+from marshmallow import fields
+
+
+class DummyObject:
+    def __init__(self):
+        self.A = None
+        self.string = "SomeString"
+
+
+class DummyDimCatConfig(DimCatConfig):
+    configured_object = DummyObject
+    string = fields.String()
+
+
+class DummyDimCatConfig2(DimCatConfig):
+    pass
+
+
+@pytest.fixture
+def dummy_object():
+    return DummyObject()
+
+
+@pytest.fixture()
+def dummy_config():
+    return DummyDimCatConfig()
+
+
+def test_object_gets_serialized(dummy_object, dummy_config):
+    result = dummy_config.dumps(dummy_object)
+    assert result["string"] == "SomeString"
+    # Assert that unspecified attribute in the config are NOT serialized :
+    assert "A" not in result.keys()
+
+
+def test_class_builder_is_serialized_and_deserialized(dummy_object, dummy_config):
+    serialized = dummy_config.dumps(dummy_object)
+    assert "_configured_type" in serialized
+
+    ds = DummyDimCatConfig.from_json(serialized)
+    # Check that the serialized deserialized it with the good type
+    assert ds["_configured_type"] == dummy_object.__class__


### PR DESCRIPTION
Fixes #10 

# Overview 

With this implementation, a config object is of the form : 

```py
from marshmallow import fields 

class NotesConfig(DimCatConfig):
    configured_object = Notes # ← mandatory
    format: NotesFormat = fields.Enum(NotesFormat)
    weight_grace_notes: float = fields.Float()
```
As `DimCatConfig` is under the hood a `Schema` of `marshmallow`, serializing/deserializing can be done like this 
```python
NotesConfig().dumps()
```
That will output a nicely JSON. The reverse operation can be done with `.loads`.

## The question of serializer's polymorphism :

This is where lies the interesting bit. There are two designs possible, and I'm not sure which one has been decided : 

### First design 

In the first one, the user has to instantiate a `Schema` (=a config object) of the **right type** to do any operation:

Example : 
 ```py
# using NotesConfig
dict_ = NotesConfig.loads(<noteconfigjson>).
# dict would be a dict of values, properly deserialized  
```

### Second design 
The second one is more complex to implement but maybe easier for the end user, as the type is **automatically inferred from the serialized data** : 

```py
d = DimCatConfig.loads(<jsonofnotesconfig>)
# d would be a dict of values, properly deserialized. The serializer to use (NotesConfig) has been deduced automatically
```

The first approach is great, simpler, cleaner (because, not need to have a registry of config objects), but disallow any use   like that 
```py
DimCatObject.from_dict(jsondataserialized)
# Impossible ! DImCatObject does not know which deserializer to use !
```
Because, well, the type of object serialized is not known in that case. 

I tried to go on the second approach in the first commit, before realizing it was maybe not the right path - so, it is quite unfinished. The global variable `_CONFIGURED_REGISTRY` (and everything related) is useless if we go for the first option ; it would be used if we chose to dynamically infer the type of the serialized data. 

Also for this reason, I didn't implement any method `DimCat.from_config`, or anything related to create an object from a config. 

As of now, this PR is quite in a very drafty state, as I cannot move forward without knowing what are the goals.

---

> Hours 
> I spent a very frustrating amount of time on it, regarding the amount of lines produced. I had to go through to a lot of docs of marshmallow to tackle the polymorphism problem.
> ~ 3h

