### PR TITLE
Proof of concept for systematic object de-/serialization using marshmallow

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,3 @@
 [settings]
-known_third_party = dimcat,frictionless,git,importlib_metadata,ms3,pandas,plotly,pytest,setuptools,typing_extensions
+known_third_party = dimcat,frictionless,git,importlib_metadata,marshmallow,ms3,pandas,plotly,pytest,setuptools,typing_extensions
 profile = black

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ python_requires = >=3.10
 install_requires =
     frictionless==5.11.1
     importlib-metadata~=6.0.0
+    marshmallow==3.19.0
     ms3>=1.1.1
     plotly==5.13.0
     seaborn~=0.12.2

--- a/src/dimcat/config.py
+++ b/src/dimcat/config.py
@@ -1,0 +1,42 @@
+from typing import TYPE_CHECKING
+
+import marshmallow as mm
+
+# To avoid circular import.
+if TYPE_CHECKING:
+    from dimcat.base import DimcatObject
+
+_CONFIGURED_REGISTRY = {}
+
+
+class DimCatConfig(mm.Schema):
+    """
+    The base class of the config system of Dimcat, with which to define custom configs. This class holds the logic for
+    serializing/deserializing config objects.
+    """
+
+    # Contains the configured class. This class is returned when loading a config object.
+    # This should be overridden by every subclass.
+    configured_object: "DimcatObject" = None
+    # This is used internally by marshmallow to deserialize the configured object.
+    # Note that this field added "manually" by add_class_builder_to_json, for practical reasons.
+    _configured_type = mm.fields.Function(deserialize=lambda v : _CONFIGURED_REGISTRY[v])
+
+    def __new__(cls, *args, **kwargs):
+        # Register a new class builder to the _CLASS_BUILDERS registry. Is used to serialize/deserialize dim cats objects
+        # configured.
+        if cls.configured_object is None:
+            raise ValueError(f"{cls} object does not have configured_object attribute !")
+        _CONFIGURED_REGISTRY[cls.configured_object.__qualname__] = cls.configured_object
+        return object.__new__(cls)
+
+    @mm.post_dump
+    def add_class_builder_to_json(self, data, **kwargs):
+        # Add the field containing the configured object class, that will be used a class builder upon deserializing.
+        data["_configured_type"] = self.configured_object.__qualname__
+        return data
+
+    @classmethod
+    def from_json(cls, json) -> dict:
+        # Instantiating cls() everytime is is quite ugly. There is likely a better solution
+        return cls().loads(json)

--- a/src/dimcat/utils.py
+++ b/src/dimcat/utils.py
@@ -6,8 +6,14 @@ import pandas as pd
 from dimcat.base import DimcatObject
 
 
+@cache
 def get_class(name) -> Type[DimcatObject]:
     return DimcatObject._registry[name]
+
+
+@cache
+def is_dimcat_class(name) -> bool:
+    return name in DimcatObject._registry
 
 
 @cache

--- a/src/dimcat/utils.py
+++ b/src/dimcat/utils.py
@@ -1,4 +1,5 @@
 """Utility functions that are or might be used by several modules or useful in external contexts."""
+from functools import cache
 from typing import Collection, Type
 
 import pandas as pd
@@ -9,19 +10,13 @@ def get_class(name) -> Type[DimcatObject]:
     return DimcatObject._registry[name]
 
 
-_SCHEMA_CACHE = {}
-
-
+@cache
 def get_schema(name, init=True):
     """Caches the intialized schema for each class. Pass init=False to retrieve the schmema constructor."""
-    if init and name in _SCHEMA_CACHE:
-        return _SCHEMA_CACHE[name]
     dc_class = get_class(name)
     dc_schema = dc_class.Schema
     if init:
-        initialized = dc_schema()
-        _SCHEMA_CACHE[name] = initialized
-        return initialized
+        return dc_schema()
     return dc_schema
 
 

--- a/src/dimcat/utils.py
+++ b/src/dimcat/utils.py
@@ -1,7 +1,28 @@
 """Utility functions that are or might be used by several modules or useful in external contexts."""
-from typing import Collection
+from typing import Collection, Type
 
 import pandas as pd
+from dimcat.base import DimcatObject
+
+
+def get_class(name) -> Type[DimcatObject]:
+    return DimcatObject._registry[name]
+
+
+_SCHEMA_CACHE = {}
+
+
+def get_schema(name, init=True):
+    """Caches the intialized schema for each class. Pass init=False to retrieve the schmema constructor."""
+    if init and name in _SCHEMA_CACHE:
+        return _SCHEMA_CACHE[name]
+    dc_class = get_class(name)
+    dc_schema = dc_class.Schema
+    if init:
+        initialized = dc_schema()
+        _SCHEMA_CACHE[name] = initialized
+        return initialized
+    return dc_schema
 
 
 def nest_level(obj, include_tuples=False):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,46 +1,126 @@
+from __future__ import annotations
+
+import json
+from itertools import product
 from pprint import pprint
 
 import pytest
-from dimcat.config import DimCatConfig
-from marshmallow import fields
+from dimcat.base import DimcatObject
+from dimcat.config import DimcatSchema
+from dimcat.utils import get_class, get_schema
+from marshmallow import ValidationError, fields
+from marshmallow.class_registry import _registry as MM_REGISTRY
 
 
-class DummyObject:
-    def __init__(self):
-        self.A = None
-        self.string = "SomeString"
+def obj_from_dict(obj_data):
+    dtype = obj_data["dtype"]
+    Constructor = get_class(dtype)
+    print(f"dtype: {dtype}, class = {Constructor}")
+    return Constructor.from_dict(obj_data)
 
 
-class DummyDimCatConfig(DimCatConfig):
-    configured_object = DummyObject
-    string = fields.String()
+def obj_from_json(json_data):
+    obj_data = json.loads(json_data)
+    return obj_from_dict(obj_data)
 
 
-class DummyDimCatConfig2(DimCatConfig):
+class BaseObject(DimcatObject):
+    @classmethod
+    def from_dict(cls, config):
+        schema = cls.Schema()
+        return schema.load(config)
+
+    @classmethod
+    def from_json(cls, config):
+        schema = cls.Schema()
+        return schema.loads(config)
+
+    class Schema(DimcatSchema):
+        strong = fields.String()
+
+    def __init__(self, strong: str):
+        self.schema = get_schema(self.name)
+        self.strong = strong
+
+    def to_dict(self) -> dict:
+        return self.schema.dump(self)
+
+    def to_json(self) -> dict:
+        return self.schema.dumps(self)
+
+
+class SubClass(BaseObject):
+    def __init__(self, strong: str, weak: bool):
+        super().__init__(strong=strong)
+        self.weak = weak
+
+    class Schema(BaseObject.Schema):
+        weak = fields.Boolean(required=True)
+
+
+class SubSubClass(SubClass):
     pass
+
+
+def test_subclass():
+    b_s = BaseObject.Schema()
+    sc_s = SubClass.Schema()
+    ssc_s = SubSubClass.Schema()
+    print(BaseObject.Schema.__qualname__, b_s.name)
+    print(SubClass.Schema.__qualname__, sc_s.name)
+    print(SubSubClass.Schema.__qualname__, ssc_s.name)
+    b_before = BaseObject(strong="Schtrong")
+    sc_before = SubClass(strong="strung", weak=True)
+    ssc_before = SubSubClass(strong="Strunk", weak=False)
+    for sch, obj in product((b_s, sc_s, ssc_s), (b_before, sc_before, ssc_before)):
+        print(f"{sch.name} dumps {obj.name}:")
+        try:
+            dump = sch.dump(obj)
+            print(dump)
+        except ValidationError as e:
+            print(e)
+            continue
+        new_obj = obj_from_dict(dump)
+        assert obj.__dict__ == new_obj.__dict__
+        json = obj.to_json()
+        print(json)
+        new_obj = obj_from_json(json)
+        assert obj.__dict__ == new_obj.__dict__
+
+
+def test_base():
+    base = BaseObject(strong="sTrOnG")
+    schema = base.Schema()
+    config1 = schema.dump(base)
+    config2 = base.to_dict()
+    assert config1 == config2
+    new_base = BaseObject.from_dict(config1)
+    print(new_base.__dict__)
 
 
 @pytest.fixture
 def dummy_object():
-    return DummyObject()
+    return BaseObject(strong="Dummy")
 
 
 @pytest.fixture()
 def dummy_config():
-    return DummyDimCatConfig()
+    return BaseObject.Schema()
 
 
-def test_object_gets_serialized(dummy_object, dummy_config):
-    result = dummy_config.dumps(dummy_object)
-    assert result["string"] == "SomeString"
-    # Assert that unspecified attribute in the config are NOT serialized :
-    assert "A" not in result.keys()
+def test_mm_registry():
+    print(MM_REGISTRY)
 
 
-def test_class_builder_is_serialized_and_deserialized(dummy_object, dummy_config):
+def test_config_comparison():
+    full1 = BaseObject.Schema()
+    full2 = BaseObject.Schema()
+    assert full1 != full2
+
+
+def test_config_validation(dummy_object, dummy_config):
     serialized = dummy_config.dumps(dummy_object)
-    assert "_configured_type" in serialized
-
-    ds = DummyDimCatConfig.from_json(serialized)
-    # Check that the serialized deserialized it with the good type
-    assert ds["_configured_type"] == dummy_object.__class__
+    print(dummy_object.__dict__)
+    pprint(dummy_config.__dict__)
+    report = dummy_config.validate(serialized)
+    print(report)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,13 +3,19 @@ from __future__ import annotations
 import json
 from itertools import product
 from pprint import pprint
+from typing import Optional, Union
+from zipfile import ZipFile
 
+import frictionless as fl
+import ms3
+import pandas as pd
 import pytest
-from dimcat.base import DimcatObject
+from dimcat.base import DimcatObject, WrappedDataframe
 from dimcat.config import DimcatConfig, DimcatSchema
 from dimcat.utils import get_schema
 from marshmallow import ValidationError, fields
 from marshmallow.class_registry import _registry as MM_REGISTRY
+from typing_extensions import Self
 
 
 def obj_from_dict(obj_data):
@@ -38,17 +44,105 @@ class BaseObject(DimcatObject):
     class Schema(DimcatSchema):
         strong = fields.String(required=True)
 
-    def __init__(self, strong: str):
+    def __init__(self, **kwargs):
         self.schema = get_schema(
             self.name
         )  # each object gets the same, cached instance
-        self.strong = strong
 
     def to_dict(self) -> dict:
         return DimcatConfig.from_object(self)
 
     def to_json(self) -> dict:
         return self.schema.dumps(self)
+
+
+class DimcatResource(BaseObject):
+    class Schema(DimcatSchema):
+        resource = fields.Method(
+            serialize="get_descriptor", deserialize="load_descriptor"
+        )
+
+        def get_descriptor(self, dc_resource: DimcatResource):
+            if dc_resource.path is None:
+                raise ValidationError(
+                    f"Cannot serialize this {dc_resource.name} because it doesn't have a file path."
+                )
+            descriptor = dc_resource.resource.to_descriptor()
+            return descriptor
+
+        def load_descriptor(self, descriptor):
+            return fl.Resource.from_descriptor(descriptor)
+
+    def __init__(self, resource: Optional[fl.Resource] = None) -> None:
+        super().__init__()
+        self.resource: fl.Resource = fl.Resource()
+        if resource is not None:
+            if isinstance(resource, fl.Resource):
+                self.resource = resource
+            else:
+                obj_name = self.__name__
+                r_type = type(resource)
+                msg = f"{obj_name} takes a frictionless.Resource, not {r_type}."
+                if issubclass(r_type, str):
+                    msg += f" Try {obj_name}.from_descriptor()"
+                raise ValueError(msg)
+
+    @property
+    def path(self):
+        return self.resource.path
+
+    @path.setter
+    def path(self, new_path):
+        self.resource.path = new_path
+
+    @classmethod
+    def from_dataframe(cls, df, **kwargs):
+        resource = fl.describe(df, **kwargs)
+        # fl.validate(resource)
+        return cls(resource=resource)
+
+    @classmethod
+    def from_descriptor(
+        cls, descriptor: Union[fl.interfaces.IDescriptor, str], **options
+    ) -> Self:
+        resource = fl.Resource.from_descriptor(descriptor, **options)
+        return cls(resource=resource)
+
+    def __str__(self):
+        return str(self.resource)
+
+    def __repr__(self):
+        return repr(self.resource)
+
+    def get_pandas(
+        self, wrapped=True
+    ) -> Union[WrappedDataframe[pd.DataFrame], pd.DataFrame]:
+        r = self.resource
+        if r.path is None:
+            raise ValidationError(
+                "The resource does not refer to a file path and cannot be restored."
+            )
+        s = r.schema
+        if r.normpath.endswith(".zip") or r.compression == "zip":
+            zip_file_handler = ZipFile(r.normpath)
+            df = ms3.load_tsv(zip_file_handler.open(r.innerpath))
+        else:
+            raise NotImplementedError()
+        if len(s.primary_key) > 0:
+            df = df.set_index(s.primary_key)
+        if wrapped:
+            return WrappedDataframe.from_df(df)
+        return df
+
+
+def test_dc_resource():
+    df = ms3.load_tsv("~/dcml_corpora/tchaikovsky_seasons/harmonies/op37a10.tsv")
+    resource = DimcatResource.from_dataframe(df=df)
+    serialized = resource.to_dict()
+    print(serialized)
+    deserialized = obj_from_dict(serialized)
+    restored_df = deserialized.get_pandas()
+    print(restored_df)
 
 
 class SubClass(BaseObject):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+from pprint import pprint
+
+import pytest
+from dimcat.config import DimCatConfig
+from marshmallow import fields
+
+
+class DummyObject:
+    def __init__(self):
+        self.A = None
+        self.string = "SomeString"
+
+
+class DummyDimCatConfig(DimCatConfig):
+    configured_object = DummyObject
+    string = fields.String()
+
+
+class DummyDimCatConfig2(DimCatConfig):
+    pass
+
+
+@pytest.fixture
+def dummy_object():
+    return DummyObject()
+
+
+@pytest.fixture()
+def dummy_config():
+    return DummyDimCatConfig()
+
+
+def test_object_gets_serialized(dummy_object, dummy_config):
+    result = dummy_config.dumps(dummy_object)
+    assert result["string"] == "SomeString"
+    # Assert that unspecified attribute in the config are NOT serialized :
+    assert "A" not in result.keys()
+
+
+def test_class_builder_is_serialized_and_deserialized(dummy_object, dummy_config):
+    serialized = dummy_config.dumps(dummy_object)
+    assert "_configured_type" in serialized
+
+    ds = DummyDimCatConfig.from_json(serialized)
+    # Check that the serialized deserialized it with the good type
+    assert ds["_configured_type"] == dummy_object.__class__


### PR DESCRIPTION
Builds on and supersedes #11

The PR has informative value and goes into the `serialization` branch, from where we might proceed to adapt the minimal working example on the `MWE` branch.

Right now, there are no `Config` objects, instead, dicts are being used.

RFC @huguesdevimeux 