### PR TITLE
Serializable Dataset (+ DimcatCatalog, DimcatPackage, DimcatResource)

### DIFF
--- a/mwe/mwe.py
+++ b/mwe/mwe.py
@@ -1,27 +1,109 @@
 import os
+from pprint import pformat
 
-from dimcat import Dataset, DimcatConfig
+import marshmallow as mm
+from dimcat import Dataset, DimcatConfig, get_class, get_schema
 from dimcat.analyzers import Counter
 from dimcat.resources.features import FeatureName
 
 if __name__ == "__main__":
     os.chdir(os.path.dirname(__file__))
+
+    # initialize the dataset
     dataset = Dataset()
     dataset.load_package("dcml_corpora.datapackage.json")
-    feature_enum = FeatureName("nOtEs")
 
-    minimal_config = DimcatConfig(dtype=feature_enum)
-    weighted_config = DimcatConfig(minimal_config, weight_grace_notes=0.5)
+    # get the metadata
+    metadata = dataset.get_metadata()
 
-    Notes_constructor = feature_enum.get_class()
-    default_config = Notes_constructor().to_config()
+    # get feature names from the enum
+    for feature_name in FeatureName:
+        assert feature_name.name == feature_name.value
 
-    analyzer_config = DimcatConfig(dtype="Counter", features=weighted_config)
-    analyzer1 = analyzer_config.create()
-    analyzer2 = Counter(features=weighted_config)
-    assert analyzer1 == analyzer2, f"{analyzer1.to_dict()} != {analyzer2.to_dict()}"
+    # feature names correspond to names of DimcatResource classes and there are two ways of getting constructors:
+    # 1. from the Enum member
+    notes_constructor = FeatureName(
+        "nOtEs"
+    ).get_class()  # spelling of string does NOT matter
+    # 2. or via the get_class() function for any DimcatObject (which the enum member uses under the hood)
+    notes_constructor = get_class("Notes")  # spelling of string DOES matter
 
-    analyzed = analyzer1.process(dataset)
-    result = analyzed.get_result()
+    # to get the default options of a feature we can serialize an instance
+    empty_notes_feature = notes_constructor()
+    print(
+        f"Default options of a Notes resource:\n"
+        f"{pformat(empty_notes_feature.to_dict())}"
+    )
+
+    # other serialization methods are .to_json(), .to_json_file(), and .to_config()
+    # the latter is used to create a DimcatConfig object which can easily be deserialized:
+    notes_config = empty_notes_feature.to_config()
+    copied_notes_feature = notes_config.create()
+    assert copied_notes_feature == empty_notes_feature
+
+    # A DimcatConfig works like a dictionary with the difference that the key 'dtype' needs to be the name of the
+    # DimcatObject it describes. It uses that object's schema to validate all given options.
+    notes_config_from_scratch = DimcatConfig(dtype="Notes")
+    notes_config_from_scratch["format"] = "NAME"
+    try:
+        notes_config_from_scratch["format"] = "this is not a valid format"
+        raise RuntimeError("Setting an invalid option should raise an error.")
+    except mm.ValidationError:
+        pass
+
+    # A DimcatConfig can be partially define a schema, creating an object from it will use the object's defaults
+    notes_feature_from_scratch = notes_config_from_scratch.create()
+    assert notes_feature_from_scratch == empty_notes_feature
+
+    # to retrieve the available options, every DimcatObject exposes the class attribute .schema
+    notes_schema = notes_constructor.schema
+    assert (
+        notes_schema == empty_notes_feature.schema == get_schema("Notes")
+    )  # the latter uses get_class()
+
+    # the types of the fields are from the marshmallow.fields module
+    for name, field in notes_schema.declared_fields.items():
+        if isinstance(field, mm.fields.Enum):
+            info = (
+                f"{name!r}: {field.enum!r} field with choices {field.choices_text!r}."
+            )
+        else:
+            info = f"{name!r}: {type(field)} field."
+        info += (
+            f"\n\tload_default={field.load_default}"
+            f"\n\tvalidate={field.validate}"
+            f"\n\tmetadata={pformat(field.metadata, sort_dicts=False)}"
+        )
+        print(info)
+
+    # analyzers have the required field 'features' which needs to include at least one
+    # DimcatConfig describing a feature
+
+    counter_config = DimcatConfig(dtype="Counter")
+    try:
+        counter_config.create()
+        raise RuntimeError(
+            "Creating an analyzer without features should raise an error."
+        )
+    except mm.ValidationError:
+        pass
+
+    # two ways of creating the identically configured Counter analyzer:
+    counter_config[
+        "features"
+    ] = notes_config  # notes_config created from empty_notes_feature above
+    a_counter = counter_config.create()
+    b_counter = get_class("Counter")(
+        features=empty_notes_feature
+    )  # passing the feature works as well
+    assert a_counter == b_counter
+    # the feature arguments are always converted to DimcaConfig objects which have the advantage
+    # that they can be partially defined. These two are equivalent ways of saying "any notes regardless their format"
+    c_counter = Counter(features="notes")
+    d_counter = Counter(features=DimcatConfig(dtype="Notes"))
+    assert c_counter == d_counter
+
+    analyzed_dataset = d_counter.process(dataset)
+    result = analyzed_dataset.get_result()
     fig = result.plot()
     print(fig)

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ python_requires = >=3.10
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
 install_requires =
-    frictionless[zenodo]==5.13.1
+    frictionless[zenodo,pandas]==5.13.1
     importlib-metadata~=6.0.0
     marshmallow==3.19.0
     ms3>=1.1.1

--- a/src/dimcat/analyzers/base.py
+++ b/src/dimcat/analyzers/base.py
@@ -144,9 +144,9 @@ class Analyzer(PipelineStep):
             required=True,
             validate=mm.validate.Length(min=1),
         )
-        strategy = mm.fields.Enum(DispatchStrategy)
-        smallest_unit = mm.fields.Enum(UnitOfAnalysis)
-        orientation = mm.fields.Enum(Orientation)
+        strategy = mm.fields.Enum(DispatchStrategy, metadata={"expose": False})
+        smallest_unit = mm.fields.Enum(UnitOfAnalysis, metadata={"expose": False})
+        orientation = mm.fields.Enum(Orientation, metadata={"expose": False})
         fill_na: mm.fields.Raw(allow_none=True)
 
         @mm.pre_load()

--- a/src/dimcat/analyzers/base.py
+++ b/src/dimcat/analyzers/base.py
@@ -147,7 +147,7 @@ class Analyzer(PipelineStep):
         strategy = mm.fields.Enum(DispatchStrategy, metadata={"expose": False})
         smallest_unit = mm.fields.Enum(UnitOfAnalysis, metadata={"expose": False})
         orientation = mm.fields.Enum(Orientation, metadata={"expose": False})
-        fill_na: mm.fields.Raw(allow_none=True)
+        fill_na = mm.fields.Raw(allow_none=True, metadata={"expose": False})
 
         @mm.pre_load()
         def features_as_list(self, obj, **kwargs):
@@ -268,7 +268,9 @@ class Analyzer(PipelineStep):
         if self.strategy == DispatchStrategy.GROUPBY_APPLY:
             stacked_feature = self.pre_process(dataset.load_feature(self.features[0]))
             results = self.groupby_apply(stacked_feature)
-            return Result(df=results, resource_name=f"{self.name.lower()}_result")
+            return Result.from_dataframe(
+                df=results, resource_name=f"{self.name.lower()}_result"
+            )
         raise ValueError(f"Unknown dispatch strategy '{self.strategy!r}'")
 
     @classmethod

--- a/src/dimcat/base.py
+++ b/src/dimcat/base.py
@@ -166,7 +166,7 @@ class DimcatObject(ABC):
     @property
     def schema(cls):
         """Returns the (instantiated) DimcatSchema singleton object for this class."""
-        return get_schema(cls.dtype)
+        return get_schema(cls.name)
 
     def to_dict(self) -> dict:
         return self.schema.dump(self)

--- a/src/dimcat/base.py
+++ b/src/dimcat/base.py
@@ -49,9 +49,14 @@ class DimcatSchema(mm.Schema):
     The base class of all Schema() classes that are defined or inherited as nested classes
     for all :class:`DimcatObjects <DimcatObject>`. This class holds the logic for serializing/deserializing DiMCAT
     objects.
+
+    The arbitrary metadata of the fields currently use the keys:
+
+    - ``expose``: Set False to mark fields that would normally not be exposed to the users in the context of an app
+                  Defaults to True if missing.
     """
 
-    dtype = DtypeField()
+    dtype = DtypeField(metadata={"expose": False})
     """This field specifies the class of the serialized object. Every DimcatObject comes with the corresponding class
     property that returns its name as a string (or en Enum member that can function as a string). It is inherited by
     all objects' schemas and enables their deserialization from a DimcatConfig."""

--- a/src/dimcat/base.py
+++ b/src/dimcat/base.py
@@ -230,6 +230,12 @@ class DimcatObject(ABC):
             json_data = f.read()
         return cls.from_json(json_data)
 
+    def __repr__(self):
+        return self.name
+
+    def __str__(self):
+        return pformat(self.to_dict(), sort_dicts=False)
+
 
 class DimcatConfig(MutableMapping, DimcatObject):
     """Behaves like a dictionary but accepts only keys and values that are valid under the Schema of the DimcatObject
@@ -420,7 +426,7 @@ class DimcatConfig(MutableMapping, DimcatObject):
         return len(self._options)
 
     def __repr__(self):
-        return f"{self.name}({pformat(self._options)})"
+        return f"{self.name}({pformat(self._options, sort_dicts=False)})"
 
     def __eq__(self, other: DimcatObject | MutableMapping) -> bool:
         """The comparison with another DimcatConfig or dict-like returns True if both describe the same object or if

--- a/src/dimcat/base.py
+++ b/src/dimcat/base.py
@@ -231,9 +231,7 @@ class DimcatObject(ABC):
         return cls.from_json(json_data)
 
     def __repr__(self):
-        from pprint import pformat
-
-        return f"{pformat(self.to_dict())}"
+        return f"{pformat(self.to_dict(), sort_dicts=False)}"
 
     def __str__(self):
         return f"{__name__}.{self.name}"

--- a/src/dimcat/base.py
+++ b/src/dimcat/base.py
@@ -52,8 +52,10 @@ class DimcatSchema(mm.Schema):
 
     The arbitrary metadata of the fields currently use the keys:
 
-    - ``expose``: Set False to mark fields that would normally not be exposed to the users in the context of an app
+    - ``expose``: Set False to mark fields that would normally not be exposed to the users in the context of a GUI.
                   Defaults to True if missing.
+    - ``title``: A human-readable title for the field.
+    - ``description``: A human-readable description for the field.
     """
 
     dtype = DtypeField(metadata={"expose": False})

--- a/src/dimcat/base.py
+++ b/src/dimcat/base.py
@@ -231,10 +231,12 @@ class DimcatObject(ABC):
         return cls.from_json(json_data)
 
     def __repr__(self):
-        return self.name
+        from pprint import pformat
+
+        return f"{pformat(self.to_dict())}"
 
     def __str__(self):
-        return pformat(self.to_dict(), sort_dicts=False)
+        return f"{__name__}.{self.name}"
 
 
 class DimcatConfig(MutableMapping, DimcatObject):

--- a/src/dimcat/dataset/base.py
+++ b/src/dimcat/dataset/base.py
@@ -28,6 +28,7 @@ from dimcat.base import Data, DimcatConfig
 from dimcat.resources.base import (
     D,
     DimcatResource,
+    SomeDataframe,
     check_file_path,
     get_default_basepath,
 )
@@ -701,6 +702,10 @@ class Dataset(Data):
     def copy(self) -> Dataset:
         """Returns a copy of this Dataset."""
         return Dataset.from_dataset(self)
+
+    def get_metadata(self) -> SomeDataframe:
+        metadata = self.get_feature("metadata")
+        return metadata.df
 
     def get_result(self, analyzer_name: Optional[str] = None) -> Result:
         """Returns the result of the previously applied analyzer with the given name."""

--- a/src/dimcat/dataset/base.py
+++ b/src/dimcat/dataset/base.py
@@ -99,7 +99,7 @@ class DimcatPackage(Data):
         package: Optional[fl.Package | str] = None,
         package_name: Optional[str] = None,
         basepath: Optional[str] = None,
-        auto_validate: bool = True,
+        auto_validate: bool = False,
     ) -> None:
         """
 
@@ -193,7 +193,7 @@ class DimcatPackage(Data):
         package: DimcatPackage,
         package_name: Optional[str] = None,
         basepath: Optional[str] = None,
-        auto_validate: bool = True,
+        auto_validate: bool = False,
     ) -> Self:
         """Create a new DimcatPackage from an existing DimcatPackage.
 
@@ -384,7 +384,7 @@ class DimcatPackage(Data):
         basepath: Optional[str] = None,
         filepath: Optional[str] = None,
         column_schema: Optional[fl.Schema | str] = None,
-        auto_validate: bool = True,
+        auto_validate: bool = False,
     ) -> None:
         """Adds a resource to the package. Parameters are passed to :class:`DimcatResource`."""
         if sum(x is not None for x in (resource, df)) == 2:
@@ -464,12 +464,12 @@ class DimcatPackage(Data):
     def __repr__(self):
         values = self._package.to_descriptor()
         values["basepath"] = self.basepath
-        return pformat(values)
+        return pformat(values, sort_dicts=False)
 
     def __str__(self):
         values = self._package.to_descriptor()
         values["basepath"] = self.basepath
-        return pformat(values)
+        return pformat(values, sort_dicts=False)
 
 
 PackageSpecs: TypeAlias = Union[DimcatPackage, fl.Package, str]
@@ -564,12 +564,14 @@ class DimcatCatalog(Data):
         package: Optional[PackageSpecs] = None,
         package_name: Optional[str] = None,
         basepath: Optional[str] = None,
-        validate: bool = True,
+        auto_validate: bool = False,
     ):
         """Adds a package to the catalog. Parameters are the same as for :class:`DimcatPackage`."""
         if package is None or isinstance(package, (fl.Package, str)):
             package = DimcatPackage(
-                package_name=package_name, basepath=basepath, auto_validate=validate
+                package_name=package_name,
+                basepath=basepath,
+                auto_validate=auto_validate,
             )
         elif not isinstance(package, DimcatPackage):
             msg = f"{self.name} takes a Package, not {type(package)!r}."

--- a/src/dimcat/resources/base.py
+++ b/src/dimcat/resources/base.py
@@ -221,7 +221,7 @@ class DimcatResource(Generic[D], Data):
 
     class PickleSchema(Data.Schema):
         resource = mm.fields.Method(
-            serialize="get_descriptor_filepath", deserialize="raw"
+            serialize="get_descriptor_filepath", deserialize="raw", allow_none=True
         )
         basepath = mm.fields.String(allow_none=True)
 
@@ -273,6 +273,8 @@ class DimcatResource(Generic[D], Data):
 
         @mm.post_load
         def init_object(self, data, **kwargs):
+            if "resource" not in data or data["resource"] is None:
+                return super().init_object(data, **kwargs)
             if isinstance(data["resource"], str) and "descriptor_filepath" not in data:
                 if os.path.isabs(data["resource"]):
                     if "basepath" in data:

--- a/src/dimcat/resources/base.py
+++ b/src/dimcat/resources/base.py
@@ -221,7 +221,9 @@ class DimcatResource(Generic[D], Data):
 
     class PickleSchema(Data.Schema):
         resource = mm.fields.Method(
-            serialize="get_descriptor_filepath", deserialize="raw", allow_none=True
+            serialize="get_descriptor_filepath",
+            deserialize="raw",
+            allow_none=True,
         )
         basepath = mm.fields.String(allow_none=True)
 
@@ -259,11 +261,15 @@ class DimcatResource(Generic[D], Data):
 
     class Schema(Data.Schema):
         resource = mm.fields.Method(
-            serialize="get_resource_descriptor", deserialize="raw"
+            serialize="get_resource_descriptor",
+            deserialize="raw",
+            metadata={"expose": False},
         )
-        basepath = mm.fields.String(allow_none=True)
-        descriptor_filepath = mm.fields.String(allow_none=True)
-        auto_validate = mm.fields.Boolean()
+        basepath = mm.fields.String(allow_none=True, metadata={"expose": False})
+        descriptor_filepath = mm.fields.String(
+            allow_none=True, metadata={"expose": False}
+        )
+        auto_validate = mm.fields.Boolean(metadata={"expose": False})
 
         def get_resource_descriptor(self, obj: DimcatResource) -> str | dict:
             return obj._resource.to_descriptor()

--- a/src/dimcat/resources/base.py
+++ b/src/dimcat/resources/base.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 import logging
 import os
 import re
+import zipfile
 from enum import IntEnum, auto
 from functools import cache
-from typing import Generic, List, Optional, TypeAlias, TypeVar, Union
+from typing import Collection, Generic, List, Optional, TypeAlias, TypeVar, Union
 from zipfile import ZipFile
 
 import frictionless as fl
+import marshmallow as mm
 import ms3
 import pandas as pd
-from dimcat.base import Data
+from dimcat.base import NEVER_STORE_UNVALIDATED_DATA, Data
+from dimcat.utils import replace_ext
 from frictionless.settings import NAME_PATTERN as FRICTIONLESS_NAME_PATTERN
-from marshmallow import ValidationError, fields
+from typing_extensions import Self
 
 try:
     import modin.pandas as mpd
@@ -31,11 +34,32 @@ D = TypeVar("D", bound=SomeDataframe)
 S = TypeVar("S", bound=SomeSeries)
 
 
-NEVER_STORE_UNVALIDATED_DATA = (
-    False  # allows for skipping mandatory validations; set to True for production
-)
-
 # region helper functions
+
+
+def check_file_path(
+    filepath: str, extensions: Optional[str | Collection[str]] = None
+) -> str:
+    """Checks that the filepath exists and raises an exception otherwise (or if it doesn't have a valid extension).
+
+    Args:
+        filepath:
+        extensions:
+
+    Returns:
+        The path turned into an absolute path.
+    """
+    path = ms3.resolve_dir(filepath)
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"File {path} does not exist.")
+    if extensions is not None:
+        if isinstance(extensions, str):
+            extensions = [extensions]
+        if not any(path.endswith(ext) for ext in extensions):
+            plural = f"one of {extensions}" if len(extensions) > 1 else extensions[0]
+            _, file_ext = os.path.splitext(path)
+            raise ValueError(f"File {path} has extension {file_ext}, not {plural}.")
+    return path
 
 
 def get_default_basepath():
@@ -74,6 +98,7 @@ def make_tsv_resource() -> fl.Resource:
     )
     options = {
         "scheme": "file",
+        "format": "tsv",
         "mediatype": "text/tsv",
         "encoding": "utf-8",
         "dialect": tsv_dialect,
@@ -114,20 +139,62 @@ class ResourceStatus(IntEnum):
 class DimcatResource(Generic[D], Data):
     """Data object wrapping a dataframe. The dataframe's metadata are stored as a :obj:`frictionless.Resource`, that
     can be used for serialization and (lazy) deserialization.
+
+    Every serialization of a DimcatResource (e.g. to store it as a config) requires that the dataframe was either
+    originally read from disk or, otherwise, that it be stored to disk. The behaviour depends on whether the resource
+    is part of a package or not.
+
+    Standalone resource (rare case)
+    -------------------------------
+
+    If the resource is not part of a package, serializing it results in two files on disk:
+
+    - the dataframe stored as ``<basepath>/<name>.tsv``
+    - the frictionless descriptor ``<basepath>/<name>.resource.json``
+
+    where ``<name>`` defaults to ``resource_name`` unless ``filepath`` is specified. The serialization has the shape
+
+    .. code-block:: python
+
+        {
+            "dtype": "DimcatResource",
+            "resource": "<name>.resource.json",
+            "basepath": "<basepath>"
+        }
+
+    A standalone resource can be instantiated in the following ways:
+
+    - ``DimcatResource()``: Creates an empty DimcatResource for setting the .df attribute later. If no ``basepath``
+      is specified, the current working directory is used if the resource is to be serialized.
+    - ``DimcatResource.from_descriptor(descriptor_path)``: The frictionless descriptor is loaded from disk.
+      Its directory is used as ``basepath``. ``descriptor_path`` is expected to end in ``.resource.json``.
+    - ``DimcatResource.from_dataframe(df=df, resource_name, basepath)``: Creates a new DimcatResource from a dataframe.
+      If ``basepath`` is not specified, the current working directory is used if the resource is to be serialized.
+    - ``DimcatResource.from_resource(resource=DimcatResource)``: Creates a DimcatResource from an existing one
+      by copying the fields it specifies.
+
+    Resource in a package (common case)
+    -----------------------------------
+
+    A DimcatResource knows that it is part of a package if its ``filepath`` ends on ``.zip``. In that case, the
+    DimcatPackage will take care of the serialization and not store an individual resource descriptor.
     """
 
     class Schema(Data.Schema):
-        resource = fields.Method(
-            serialize="get_resource_descriptor", deserialize="load_descriptor"
+        resource = mm.fields.Method(
+            serialize="get_resource_descriptor", deserialize="raw"
         )
+        basepath = mm.fields.String(allow_none=True)
 
-        def get_resource_descriptor(self, obj: DimcatResource):
-            if ResourceStatus.SCHEMA < obj.status < ResourceStatus.SERIALIZED:
+        def get_resource_descriptor(self, obj: DimcatResource) -> str | dict:
+            if ResourceStatus.DATAFRAME <= obj.status < ResourceStatus.SERIALIZED:
                 logger.info(
                     f"This {self.name} needs to be stored to disk to be expressed as restorable config."
                 )
                 if obj.status <= ResourceStatus.VALIDATED:
                     obj.store_dataframe()
+            if not obj.is_zipped_resource:
+                return obj.descriptor_filepath
             if obj.status < ResourceStatus.DATAFRAME:
                 descriptor = {}
             else:
@@ -140,17 +207,23 @@ class DimcatResource(Generic[D], Data):
             # ToDo: store the descriptor to disk and return the path
             return descriptor
 
-        def load_descriptor(self, data):
-            return fl.Resource(data)
+        def raw(self, data):
+            return data
+
+        @mm.post_load
+        def init_object(self, data, **kwargs):
+            if isinstance(data["resource"], str) and "basepath" in data:
+                descriptor_path = os.path.join(data["basepath"], data["resource"])
+                data["resource"] = descriptor_path
+            return super().init_object(data, **kwargs)
 
     def __init__(
         self,
-        resource: Optional[fl.Resource | str] = None,
+        resource: Optional[str, fl.Resource] = None,
         resource_name: Optional[str] = None,
-        df: Optional[D] = None,
-        column_schema: Optional[fl.Schema | str] = None,
         basepath: Optional[str] = None,
         filepath: Optional[str] = None,
+        column_schema: Optional[fl.Schema | str] = None,
         validate: bool = True,
     ) -> None:
         """
@@ -160,10 +233,6 @@ class DimcatResource(Generic[D], Data):
             resource_name:
                 Name of the resource. Used as filename if the resource is stored to a ZIP file. Defaults to
                 :meth:`filename_factory`.
-            df: DataFrame that this object wraps.
-            column_schema:
-                If you don't pass a schema or a path or URL to one, frictionless will try to infer it. However,
-                this often leads to validation errors.
             basepath:
                 The absolute path on the local file system, relative to which the resource will be described when
                 written to disk. If not specified, it will default to
@@ -174,59 +243,202 @@ class DimcatResource(Generic[D], Data):
             filepath:
                 The path to the existing or future tabular resource on physical disk.
 
+                * If None it defaults to ``resource_name`` with the extension ``.tsv`` (which also serves as innerpath
+                  in case ``filepath`` points to a ZIP file).
                 * If it is a relative path, it will be appended to the ``basepath``.
                 * If it is an absolute path, the directory will be used as ``basepath``, unless a basepath is specified,
                   in which case filepath must be contained in it, so that it can be expressed relatively to it.
 
+            column_schema:
+                If you don't pass a schema or a path or URL to one, frictionless will try to infer it. However,
+                this often leads to validation errors.
             validate:
                 By default, the DimcatResource will not be instantiated if the schema validation fails. Set to
                 False if you want to skip the validation.
         """
+        print(
+            f"DimcatResource.__init__(resource={resource!r}, resource_name={resource_name!r}, basepath={basepath!r}, "
+            f"filepath={filepath!r}, column_schema={column_schema!r}, validate={validate!r})"
+        )
         super().__init__()
         self._resource: fl.Resource = make_tsv_resource()
         self._status = ResourceStatus.EMPTY
         self._df: D = None
-        self.descriptor_path: Optional[str] = None
+        self._descriptor_filepath: Optional[str] = None
+
+        if basepath is not None:
+            basepath = ms3.resolve_dir(basepath)
 
         if resource is not None:
-            if resource_name is None:
-                self.resource_name = self.filename_factory()
-            else:
-                # this purposefully happens twice, the first time to allow for computing paths when setting a resource
-                # and the second time to overwrite the name of the given resource
-                self.resource_name = resource_name
             if isinstance(resource, str):
-                self._resource = fl.Resource(resource)
-                self.basepath = os.path.dirname(resource)
-                assert self.normpath is not None and os.path.isfile(self.normpath), (
-                    f"Resource does not point to an existing file "
-                    f"(basepath: {self.basepath}):\n{self._resource}"
+                descriptor_path = check_file_path(
+                    resource, extensions=("resource.json", "resource.yaml")
                 )
-                self.descriptor_path = self.normpath
-                self._status = ResourceStatus.ON_DISK_NOT_LOADED
+                fl_resource = fl.Resource(descriptor_path)
+                descriptor_dir, descriptor_filepath = os.path.split(descriptor_path)
+                self._descriptor_filepath = descriptor_filepath
+                if basepath is not None and basepath != descriptor_dir:
+                    raise ValueError(
+                        f"basepath {basepath!r} does not match the directory of the descriptor {descriptor_path!r}"
+                    )
+                if not fl_resource.basepath:
+                    fl_resource.basepath = descriptor_dir
             elif isinstance(resource, fl.Resource):
-                self._resource = resource
-                if resource.scheme == "file":
-                    self._status = ResourceStatus.ON_DISK_NOT_LOADED
+                fl_resource = resource
             else:
                 raise TypeError(
                     f"Expected a path or a frictionless resource, got {type(resource)}"
                 )
+            if not os.path.isfile(fl_resource.normpath):
+                raise FileNotFoundError(
+                    f"Described resource {descriptor_path} does not exist."
+                )
+            self._status = ResourceStatus.ON_DISK_NOT_LOADED
+            self._resource = fl_resource
+
+        if basepath is None:
+            if not self.basepath:
+                if filepath is None or os.path.isrel(filepath):
+                    self.basepath = get_default_basepath()
+                    logger.info(f"Using default basepath: {self.basepath}")
 
         if resource_name is not None:
-            self._resource.name = resource_name
+            self.resource_name = resource_name
         if column_schema is not None:
             self.column_schema = column_schema
-        if df is not None:
-            self.df = df
         if basepath is not None:
             self.basepath = basepath
         if filepath is not None:
             self.filepath = filepath
         if not self.is_frozen and self.is_serialized:
-            self._status = ResourceStatus.SERIALIZED
+            if self.is_zipped_resource or os.path.isfile(self.descriptor_path):
+                if self._df is None:
+                    self._status = ResourceStatus.ON_DISK_NOT_LOADED
+                else:
+                    self._status = ResourceStatus.ON_DISK_AND_LOADED
+            else:
+                self._status = ResourceStatus.SERIALIZED
         if validate and self.status == ResourceStatus.DATAFRAME:
             _ = self.validate(raise_exception=NEVER_STORE_UNVALIDATED_DATA)
+
+    # @classmethod
+    # def from_dict(cls, options, **kwargs) -> Self:
+    #     options = dict(options, **kwargs)
+    #     if sum(arg in options for arg in ("resource", "resource_name", "df")) == 0:
+    #         raise ValueError(f"Expected at least one of 'resource', 'resource_name', 'df', got {options}.")
+    #     if "dtype" in options:
+    #         source_dtype = options.pop("dtype")
+    #         if source_dtype != cls.name:
+    #             logger.warning(f"The given dict specified dtype={source_dtype!r}, but we're creating a {cls.name}.")
+    #     return cls(**options)
+    #
+    # @classmethod
+    # def from_config(cls, config: DimcatConfig, **kwargs) -> Self:
+    #     """Create a DimcatResource from a DimcatConfig describing a resource."""
+    #     return cls.from_dict(config.options, **kwargs)
+
+    @classmethod
+    def from_descriptor(
+        cls,
+        descriptor_path: str,
+        validate: bool = True,
+    ) -> Self:
+        """Create a DimcatResource by loading its frictionless descriptor is loaded from disk.
+        The descriptor's directory is used as ``basepath``. ``descriptor_path`` is expected to end in
+        ``.resource.json``.
+
+        Args:
+            descriptor_path: Needs to be an absolute path and is expected to end in ``.resource.json``.
+            validate:
+                By default, the DimcatResource will not be instantiated if the schema validation fails. Set to
+                False if you want to skip the validation.
+        """
+        return cls(resource=descriptor_path, validate=validate)
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        df: D,
+        resource_name: str,
+        basepath: Optional[str] = None,
+        filepath: Optional[str] = None,
+        column_schema: Optional[fl.Schema | str] = None,
+        validate: bool = True,
+    ) -> Self:
+        """Create a DimcatResource from a dataframe, specifying its name and, optionally, at what path it is to be
+        serialized.
+
+        Args:
+            df: Dataframe to create the resource from.
+            resource_name:
+                Name of the resource used for retrieving it from a DimcatPackage and as filename when the resource
+                is stored to a ZIP file.
+            basepath:
+                The absolute path on the local file system, relative to which the resource will be described when
+                written to disk. If not specified, it will default to
+
+                * the current working directory if no ``filepath`` is given or the given filepath is relative
+                * the ``filepath``'s directory if the filepath is absolute
+
+            filepath:
+                The path to the existing or future tabular resource on physical disk.
+
+                * If None it defaults to ``resource_name`` with the extension ``.tsv`` (which also serves as innerpath
+                  in case ``filepath`` points to a ZIP file).
+                * If it is a relative path, it will be appended to the ``basepath``.
+                * If it is an absolute path, the directory will be used as ``basepath``, unless a basepath is specified,
+                  in which case filepath must be contained in it, so that it can be expressed relatively to it.
+
+            column_schema:
+                If you don't pass a schema or a path or URL to one, frictionless will try to infer it. However,
+                this often leads to validation errors.
+        """
+        new_resource = cls(
+            resource_name=resource_name,
+            basepath=basepath,
+            filepath=filepath,
+            column_schema=column_schema,
+            validate=validate,
+        )
+        new_resource.df = df
+        return new_resource
+
+    @classmethod
+    def from_resource(
+        cls,
+        resource: DimcatResource,
+        resource_name: Optional[str] = None,
+        basepath: Optional[str] = None,
+        filepath: Optional[str] = None,
+        column_schema: Optional[fl.Schema | str] = None,
+        validate: bool = True,
+    ) -> Self:
+        """Create a DimcatResource from an existing DimcatResource, specifying its name and, optionally, at what path
+        it is to be serialized.
+
+        Args:
+            resource:
+            resource_name:
+            basepath:
+            filepath:
+            column_schema:
+            validate:
+        """
+        if not isinstance(resource, DimcatResource):
+            raise TypeError(f"Expected a DimcatResource, got {type(resource)!r}.")
+        fl_resource = resource.resource
+        if resource_name is not None:
+            fl_resource.name = resource_name
+        if basepath is not None:
+            fl_resource.basepath = basepath
+        if filepath is not None:
+            fl_resource.path = filepath
+        if column_schema is not None:
+            fl_resource.schema = column_schema
+        return cls(
+            resource=resource.resource,
+            validate=validate,
+        )
 
     @property
     def basepath(self):
@@ -234,9 +446,13 @@ class DimcatResource(Generic[D], Data):
 
     @basepath.setter
     def basepath(self, basepath):
+        basepath = ms3.resolve_dir(basepath)
         if self.is_frozen:
+            if basepath == self.basepath:
+                return
             raise RuntimeError(
-                "Cannot set basepath on a resource whose valid descriptor has been written to disk."
+                f"The basepath of resource {self.name!r} ({self.basepath!r}) cannot be changed to {basepath!r} "
+                f"because it's tied to its descriptor at {self.descriptor_path!r}."
             )
         assert os.path.isdir(
             basepath
@@ -270,6 +486,16 @@ class DimcatResource(Generic[D], Data):
             self._status = ResourceStatus.DATAFRAME
 
     @property
+    def descriptor_filepath(self) -> str:
+        """The path to the descriptor file on disk, relative to the basepath. If it hasn't been set, it will be
+        generated by :meth:`generate_descriptor_path`."""
+        if self._descriptor_filepath is not None:
+            return self._descriptor_filepath
+        standalone_path = os.path.join(self.basepath, self.innerpath)
+        self._descriptor_filepath = replace_ext(standalone_path, ".resource.json")
+        return self._descriptor_filepath
+
+    @property
     def df(self) -> D:
         if self._df is not None:
             return self._df
@@ -292,6 +518,8 @@ class DimcatResource(Generic[D], Data):
 
     @property
     def filepath(self):
+        if self._resource.path is None:
+            return self.innerpath
         return self._resource.path
 
     @filepath.setter
@@ -319,9 +547,18 @@ class DimcatResource(Generic[D], Data):
         self._resource.path = filepath
 
     @property
+    def innerpath(self):
+        """The innerpath is the resource_name plus the extension .tsv and is used as filename within a .zip archive."""
+        if self.resource_name.endswith(".tsv"):
+            return self.resource_name
+        return self.resource_name + ".tsv"
+
+    @property
     def is_frozen(self) -> bool:
         """Whether the resource is frozen (i.e. its valid descriptor has been written to disk) or not."""
-        return self.status >= ResourceStatus.ON_DISK_AND_LOADED
+        return (
+            self.is_zipped_resource or self.status >= ResourceStatus.ON_DISK_AND_LOADED
+        )
 
     @property
     def is_loaded(self) -> bool:
@@ -331,7 +568,15 @@ class DimcatResource(Generic[D], Data):
 
     @property
     def is_serialized(self) -> bool:
-        return self.normpath is not None and os.path.isfile(self.normpath)
+        """Returns True if the resource is serialized (i.e. its dataframe has been written to disk)."""
+        if self.normpath is None:
+            return False
+        if not os.path.isfile(self.normpath):
+            return False
+        if not self.is_zipped_resource:
+            return True
+        with zipfile.ZipFile(self.normpath) as zip_file:
+            return self.innerpath in zip_file.namelist()
 
     @property
     def is_valid(self) -> bool:
@@ -344,10 +589,19 @@ class DimcatResource(Generic[D], Data):
             return report.valid
 
     @property
+    def is_zipped_resource(self) -> bool:
+        """Returns True if the filepath points to a .zip file. This means that the resource is part of a package
+        and serializes to a dict instead of a descriptor file.
+        """
+        if self.filepath is None:
+            raise RuntimeError(
+                f"Cannot determine whether resource {self.name} is zipped because it has no filepath."
+            )
+        return self.filepath.endswith(".zip")
+
+    @property
     def normpath(self) -> Optional[str]:
         """Absolute path to the serialized or future tabular file."""
-        if self.descriptor_path is not None:
-            return self.descriptor_path
         n_specified = sum(path is not None for path in (self.basepath, self.filepath))
         if n_specified == 0:
             return
@@ -365,6 +619,8 @@ class DimcatResource(Generic[D], Data):
 
     @property
     def resource_name(self):
+        if not self._resource.name:
+            return self.filename_factory()
         return self._resource.name
 
     @resource_name.setter
@@ -375,8 +631,6 @@ class DimcatResource(Generic[D], Data):
                 f"Name must be lowercase and work as filename: {name_lower!r}"
             )
         self._resource.name = name_lower
-        if self.filepath is None:
-            self.filepath = name_lower + ".tsv"
 
     @property
     def status(self) -> ResourceStatus:
@@ -397,7 +651,7 @@ class DimcatResource(Generic[D], Data):
         """
         r = self._resource
         if self.normpath is None:
-            raise ValidationError(
+            raise mm.ValidationError(
                 f"The resource does not refer to a file path and cannot be loaded.\n"
                 f"basepath: {self.basepath}, filepath: {self.filepath}"
             )
@@ -411,7 +665,7 @@ class DimcatResource(Generic[D], Data):
         if self.status == ResourceStatus.ON_DISK_NOT_LOADED:
             self._status = ResourceStatus.ON_DISK_AND_LOADED
         if wrapped:
-            return DimcatResource(df=df)
+            return DimcatResource()
         return df
 
     def load(self, force_reload: bool = False):
@@ -433,24 +687,16 @@ class DimcatResource(Generic[D], Data):
         if validate and self.status < ResourceStatus.VALIDATED:
             _ = self.validate(raise_exception=NEVER_STORE_UNVALIDATED_DATA)
 
-        if name is not None:
-            filepath = name
-        elif self.filepath is not None:
-            filepath = self.filepath
-        else:
-            filepath = self.filename_factory()
-        if not filepath.endswith(".tsv"):
-            filepath += ".tsv"
-        self.filepath = filepath
-        if self.basepath is None:
-            self.basepath = get_default_basepath()
-        full_path = os.path.normpath(os.path.join(self.basepath, filepath))
+        full_path = self.normpath
         if os.path.isfile(full_path):
             raise RuntimeError(
                 f"File exists already on disk and will not be overwritten: {full_path}"
             )
         ms3.write_tsv(self.df, full_path)
         self._status = ResourceStatus.SERIALIZED
+        descriptor_path = os.path.join(self.basepath, self.descriptor_filepath)
+        self.resource.to_json(descriptor_path)
+        self._status = ResourceStatus.ON_DISK_AND_LOADED
 
     def validate(self, raise_exception: bool = False) -> Optional[fl.Report]:
         if self.status < ResourceStatus.DATAFRAME:
@@ -467,6 +713,8 @@ class DimcatResource(Generic[D], Data):
                 self._status = ResourceStatus.VALIDATED
         elif raise_exception:
             errors = [err.message for task in report.tasks for err in task.errors]
+            if self.status == ResourceStatus.VALIDATED:
+                self._status = ResourceStatus.DATAFRAME
             raise fl.FrictionlessException("\n".join(errors))
         return report
 

--- a/src/dimcat/resources/base.py
+++ b/src/dimcat/resources/base.py
@@ -444,10 +444,16 @@ class DimcatResource(Generic[D], Data):
             fl_resource.path = filepath
         if column_schema is not None:
             fl_resource.schema = column_schema
-        return cls(
+        new_object = cls(
             resource=resource.resource,
             auto_validate=auto_validate,
         )
+        if resource._df is not None:
+            new_object._df = resource._df.copy()
+        if resource._descriptor_filepath is not None:
+            new_object._descriptor_filepath = resource._descriptor_filepath
+        new_object._status = resource._status
+        return new_object
 
     @property
     def basepath(self):

--- a/src/dimcat/resources/base.py
+++ b/src/dimcat/resources/base.py
@@ -638,6 +638,13 @@ class DimcatResource(Generic[D], Data):
             self._status = ResourceStatus.SCHEMA
         return self._status
 
+    def get_descriptor_path(self, only_if_exists=True) -> Optional[str]:
+        """Returns the path to the descriptor file."""
+        descriptor_path = os.path.join(self.basepath, self.descriptor_filepath)
+        if only_if_exists and not os.path.isfile(descriptor_path):
+            return
+        return descriptor_path
+
     @cache
     def get_dataframe(self, wrapped=True) -> Union[DimcatResource[D], D]:
         """

--- a/src/dimcat/resources/base.py
+++ b/src/dimcat/resources/base.py
@@ -581,7 +581,7 @@ class DimcatResource(Generic[D], Data):
     @property
     def is_valid(self) -> bool:
         if self.status < ResourceStatus.DATAFRAME:
-            return False
+            return True
         if self.status >= ResourceStatus.VALIDATED:
             return True
         report = self.validate()

--- a/src/dimcat/resources/features.py
+++ b/src/dimcat/resources/features.py
@@ -5,7 +5,7 @@ from typing import Optional, Type
 
 import frictionless as fl
 from dimcat import get_class
-from dimcat.resources.base import D, DimcatResource
+from dimcat.resources.base import DimcatResource
 from marshmallow import fields
 from typing_extensions import Self
 
@@ -66,12 +66,12 @@ class Notes(Feature):
         self,
         format: NotesFormat = NotesFormat.FIFTHS,
         weight_grace_notes: float = 0.0,
-        df: Optional[D] = None,
         resource_name: Optional[str] = None,
         resource: Optional[fl.Resource | str] = None,
         column_schema: Optional[fl.Schema | str] = None,
         basepath: Optional[str] = None,
         filepath: Optional[str] = None,
+        descriptor_filepath: Optional[str] = None,
         auto_validate: bool = True,
     ) -> None:
         self._format: NotesFormat = format
@@ -82,6 +82,7 @@ class Notes(Feature):
             basepath=basepath,
             filepath=filepath,
             column_schema=column_schema,
+            descriptor_filepath=descriptor_filepath,
             auto_validate=auto_validate,
         )
 

--- a/src/dimcat/resources/features.py
+++ b/src/dimcat/resources/features.py
@@ -79,10 +79,9 @@ class Notes(Feature):
         super().__init__(
             resource=resource,
             resource_name=resource_name,
-            df=df,
-            column_schema=column_schema,
             basepath=basepath,
             filepath=filepath,
+            column_schema=column_schema,
             validate=validate,
         )
 

--- a/src/dimcat/resources/features.py
+++ b/src/dimcat/resources/features.py
@@ -4,9 +4,9 @@ from enum import Enum
 from typing import Optional, Type
 
 import frictionless as fl
+import marshmallow as mm
 from dimcat import get_class
 from dimcat.resources.base import DimcatResource
-from marshmallow import fields
 from typing_extensions import Self
 
 
@@ -59,12 +59,29 @@ class NotesFormat(str, Enum):
 
 class Notes(Feature):
     class Schema(Feature.Schema):
-        format = fields.Enum(NotesFormat)
-        weight_grace_notes = fields.Float()
+        format = mm.fields.Enum(NotesFormat)
+        merge_ties = mm.fields.Boolean(
+            load_default=True,
+            metadata=dict(
+                title="Merge tied notes",
+                description="If set, notes that are tied together in the score are merged together, counting them "
+                "as a single event of the corresponding length. Otherwise, every note head is counted.",
+            ),
+        )
+        weight_grace_notes = mm.fields.Float(
+            load_default=0.0,
+            validate=mm.validate.Range(min=0.0, max=1.0),
+            metadata=dict(
+                title="Weight grace notes",
+                description="Set a factor > 0.0 to multiply the nominal duration of grace notes which, otherwise, have "
+                "duration 0 and are therefore excluded from many statistics.",
+            ),
+        )
 
     def __init__(
         self,
-        format: NotesFormat = NotesFormat.FIFTHS,
+        format: NotesFormat = NotesFormat.NAME,
+        merge_ties: bool = True,
         weight_grace_notes: float = 0.0,
         resource_name: Optional[str] = None,
         resource: Optional[fl.Resource | str] = None,

--- a/src/dimcat/resources/features.py
+++ b/src/dimcat/resources/features.py
@@ -72,7 +72,7 @@ class Notes(Feature):
         column_schema: Optional[fl.Schema | str] = None,
         basepath: Optional[str] = None,
         filepath: Optional[str] = None,
-        validate: bool = True,
+        auto_validate: bool = True,
     ) -> None:
         self._format: NotesFormat = format
         self._weight_grace_notes: float = weight_grace_notes
@@ -82,7 +82,7 @@ class Notes(Feature):
             basepath=basepath,
             filepath=filepath,
             column_schema=column_schema,
-            validate=validate,
+            auto_validate=auto_validate,
         )
 
     @property

--- a/src/dimcat/utils.py
+++ b/src/dimcat/utils.py
@@ -1,4 +1,7 @@
 """Utility functions that are or might be used by several modules or useful in external contexts."""
+from __future__ import annotations
+
+import os
 from typing import Collection
 
 import pandas as pd
@@ -129,3 +132,24 @@ def interval_index2interval(ix):
     left = ix.left.min()
     right = ix.right.max()
     return pd.Interval(left, right, closed="left")
+
+
+def replace_ext(filepath, new_ext):
+    """Replace the extension of any given file path with a new one which can be given with or without a leading dot."""
+    file, _ = os.path.splitext(filepath)
+    if file.split(".")[-1] in ("resource", "datapackage", "package"):
+        file = ".".join(file.split(".")[:-1])
+    if new_ext[0] != ".":
+        new_ext = "." + new_ext
+    return file + new_ext
+
+
+def get_object_value(obj, key, default):
+    """Return obj[key] if possible, obj.key otherwise. Code copied from marshmallow.utils._get_value_for_key()"""
+    if not hasattr(obj, "__getitem__"):
+        return getattr(obj, key, default)
+
+    try:
+        return obj[key]
+    except (KeyError, IndexError, TypeError, AttributeError):
+        return getattr(obj, key, default)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,233 +1,282 @@
 """
-    Dummy conftest.py for dimcat.
-
-    If you don't know what this is for, just leave it empty.
-    Read more about conftest.py under:
-    - https://docs.pytest.org/en/stable/fixture.html
-    - https://docs.pytest.org/en/stable/writing_plugins.html
+Configuring the test suite.
 """
-import math
 import os
-from collections import defaultdict
 
+import pandas as pd
 import pytest
-from dimcat.analyzer import (
-    ChordSymbolBigrams,
-    ChordSymbolUnigrams,
-    PitchClassVectors,
-    TPCrange,
-)
-from dimcat.dataset import Dataset
-from dimcat.filter import IsAnnotatedFilter
-from dimcat.grouper import CorpusGrouper, ModeGrouper, PieceGrouper, YearGrouper
-from dimcat.pipeline import Pipeline
-from dimcat.slicer import LocalKeySlicer, MeasureSlicer, NoteSlicer, PhraseSlicer
+from dimcat.resources.base import DimcatResource
 from git import Repo
-from ms3 import pretty_dict
 
-# Directory holding your clones of DCMLab/unittest_metacorpus & DCMLab/pleyel_quartets
+# ----------------------------- SETTINGS -----------------------------
+# Directory holding your clone of github.com/DCMLab/unittest_metacorpus
 CORPUS_DIR = "~"
 
 
-@pytest.fixture(
-    scope="session",
-    params=[
-        ("pleyel_quartets", "10a25eb"),
-        ("unittest_metacorpus", "2d922c7"),
-    ],
-    ids=[
-        "corpus",
-        "metacorpus",
-    ],
-)
-def small_corpora_path(request):
+def corpus_path():
     """Compose the paths for the test corpora."""
     print("Path was requested")
-    repo_name, test_commit = request.param
+    repo_name, test_commit = ("unittest_metacorpus", "e6fec84")
     path = os.path.join(CORPUS_DIR, repo_name)
     path = os.path.expanduser(path)
     assert os.path.isdir(path)
     repo = Repo(path)
     commit = repo.commit("HEAD")
     sha = commit.hexsha[: len(test_commit)]
-    assert sha == test_commit
+    assert (
+        sha == test_commit
+    ), f"Your {path} is @ {sha}. Please do\n\tgit checkout {test_commit}."
     return path
 
 
-@pytest.fixture(scope="session")
-def all_corpora_path():
-    path = os.path.join(CORPUS_DIR, "all_subcorpora")
-    return path
+CORPUS_PATH = corpus_path()
+RESOURCE_PATHS = {
+    file: os.path.join(CORPUS_PATH, file)
+    for file in os.listdir(CORPUS_PATH)
+    if file.endswith(".resource.yaml")
+}
 
 
-@pytest.fixture(
-    scope="session",
-    params=[
-        (Dataset, True, False),
-        #        (Corpus, False, True),
-        #        (Corpus, True, True),
-    ],
-    ids=[
-        "TSV only",
-        #        "scores only",
-        #        "TSV + scores"
-    ],
-)
-def corpus(small_corpora_path, request):
-    path = small_corpora_path
-    obj, tsv, scores = request.param
-    initialized_obj = obj(directory=path, parse_tsv=tsv, parse_scores=scores)
-    print(
-        f"\nInitialized {type(initialized_obj).__name__}(directory='{path}', "
-        f"parse_tsv={tsv}, parse_scores={scores})"
-    )
-    return initialized_obj
-
-
-@pytest.fixture(
-    params=[True, False],
-    ids=["once_per_group", ""],
-)
-def once_per_group(request):
+@pytest.fixture(params=RESOURCE_PATHS.values(), ids=RESOURCE_PATHS)
+def resource_path(request):
     return request.param
 
 
-@pytest.fixture(
-    params=[
-        TPCrange,
-        PitchClassVectors,
-        ChordSymbolUnigrams,
-        ChordSymbolBigrams,
-    ],
-    ids=["TPCrange", "PitchClassVectors", "ChordSymbolUnigrams", "ChordSymbolBigrams"],
-)
-def analyzer(once_per_group, request):
-    return request.param(once_per_group=once_per_group)
+def single_resource_path() -> str:
+    """Returns the path to a single resource."""
+    return RESOURCE_PATHS["unittest_notes.resource.yaml"]
 
 
-@pytest.fixture(
-    scope="session",
-    params=[
-        PhraseSlicer(),
-        MeasureSlicer(),
-        NoteSlicer(1),
-        NoteSlicer(),
-        LocalKeySlicer(),
-    ],
-    ids=[
-        "PhraseSlicer",
-        "MeasureSlicer",
-        "NoteSlicer_quarters",
-        "NoteSlicer_onsets",
-        "LocalKeySlicer",
-    ],
-)
-def slicer(request):
-    return request.param
+def single_dataframe() -> pd.DataFrame:
+    """Creates a DimcatResource and returns its dataframe."""
+    return DimcatResource(single_resource_path()).df
 
 
-@pytest.fixture(
-    scope="session",
-)
-def apply_slicer(slicer, corpus):
-    sliced_data = slicer.process_data(corpus)
-    print(
-        f"\n{len(corpus.indices[()])} indices before slicing, after: {len(sliced_data.indices[()])}"
-    )
-    assert len(sliced_data.sliced) > 0
-    assert len(sliced_data.slice_info) > 0
-    assert len(sliced_data.index_levels["indices"]) > 2
-    assert len(sliced_data.index_levels["slicer"]) > 0
-    for facet, sliced in sliced_data.sliced.items():
-        grouped_by_piece = defaultdict(list)
-        for id, chunk in sliced.items():
-            assert chunk.index.nlevels == 1
-            assert len(id) == 3
-            piece_id = id[:2]
-            grouped_by_piece[piece_id].extend(chunk.duration_qb.to_list())
-        for piece_id, durations in grouped_by_piece.items():
-            # test if the facet slices add up to the same duration as the original facet
-            facet_duration = sliced_data.get_item(piece_id, facet).duration_qb
-            adds_up = math.isclose(sum(durations), facet_duration.sum())
-            if not adds_up:
-                print(
-                    f"{piece_id}: Durations for facet {facet} sum up to {facet_duration.sum()}, "
-                    f"but the slices add up to {sum(durations)}"
-                )
-    return sliced_data
+def datapackage_json_path() -> str:
+    """Returns the path to a single resource."""
+    return os.path.join(CORPUS_PATH, "datapackage.json")
 
 
-@pytest.fixture(
-    scope="session",
-)
-def sliced_data(apply_slicer):
-    return apply_slicer
+# region deprecated
 
+# OLD TEST SETUP FROM v0.3.0
+# import math
+# import os
+# from collections import defaultdict
+# from dimcat.analyzer import (
+#     ChordSymbolBigrams,
+#     ChordSymbolUnigrams,
+#     PitchClassVectors,
+#     TPCrange,
+# )
+# from dimcat.dataset import Dataset
+# from dimcat.filter import IsAnnotatedFilter
+# from dimcat.grouper import CorpusGrouper, ModeGrouper, PieceGrouper, YearGrouper
+# from dimcat.pipeline import Pipeline
+# from dimcat.slicer import LocalKeySlicer, MeasureSlicer, NoteSlicer, PhraseSlicer
+# from git import Repo
+# from ms3 import pretty_dict
+# @pytest.fixture(
+#     scope="session",
+#     params=[
+#         ("pleyel_quartets", "10a25eb"),
+#         ("unittest_metacorpus", "2d922c7"),
+#     ],
+#     ids=[
+#         "corpus",
+#         "metacorpus",
+#     ],
+# )
+# def small_corpora_path(request):
+#     """Compose the paths for the test corpora."""
+#     print("Path was requested")
+#     repo_name, test_commit = request.param
+#     path = os.path.join(CORPUS_DIR, repo_name)
+#     path = os.path.expanduser(path)
+#     assert os.path.isdir(path)
+#     repo = Repo(path)
+#     commit = repo.commit("HEAD")
+#     sha = commit.hexsha[: len(test_commit)]
+#     assert sha == test_commit
+#     return path
+#
+#
+# @pytest.fixture(scope="session")
+# def all_corpora_path():
+#     path = os.path.join(CORPUS_DIR, "all_subcorpora")
+#     return path
+#
+#
+# @pytest.fixture(
+#     scope="session",
+#     params=[
+#         (Dataset, True, False),
+#         #        (Corpus, False, True),
+#         #        (Corpus, True, True),
+#     ],
+#     ids=[
+#         "TSV only",
+#         #        "scores only",
+#         #        "TSV + scores"
+#     ],
+# )
+# def corpus(small_corpora_path, request):
+#     path = small_corpora_path
+#     obj, tsv, scores = request.param
+#     initialized_obj = obj(directory=path, parse_tsv=tsv, parse_scores=scores)
+#     print(
+#         f"\nInitialized {type(initialized_obj).__name__}(directory='{path}', "
+#         f"parse_tsv={tsv}, parse_scores={scores})"
+#     )
+#     return initialized_obj
+#
+#
+# @pytest.fixture(
+#     params=[True, False],
+#     ids=["once_per_group", ""],
+# )
+# def once_per_group(request):
+#     return request.param
+#
+#
+# @pytest.fixture(
+#     params=[
+#         TPCrange,
+#         PitchClassVectors,
+#         ChordSymbolUnigrams,
+#         ChordSymbolBigrams,
+#     ],
+#     ids=["TPCrange", "PitchClassVectors", "ChordSymbolUnigrams", "ChordSymbolBigrams"],
+# )
+# def analyzer(once_per_group, request):
+#     return request.param(once_per_group=once_per_group)
+#
+#
+# @pytest.fixture(
+#     scope="session",
+#     params=[
+#         PhraseSlicer(),
+#         MeasureSlicer(),
+#         NoteSlicer(1),
+#         NoteSlicer(),
+#         LocalKeySlicer(),
+#     ],
+#     ids=[
+#         "PhraseSlicer",
+#         "MeasureSlicer",
+#         "NoteSlicer_quarters",
+#         "NoteSlicer_onsets",
+#         "LocalKeySlicer",
+#     ],
+# )
+# def slicer(request):
+#     return request.param
+#
+#
+# @pytest.fixture(
+#     scope="session",
+# )
+# def apply_slicer(slicer, corpus):
+#     sliced_data = slicer.process_data(corpus)
+#     print(
+#         f"\n{len(corpus.indices[()])} indices before slicing, after: {len(sliced_data.indices[()])}"
+#     )
+#     assert len(sliced_data.sliced) > 0
+#     assert len(sliced_data.slice_info) > 0
+#     assert len(sliced_data.index_levels["indices"]) > 2
+#     assert len(sliced_data.index_levels["slicer"]) > 0
+#     for facet, sliced in sliced_data.sliced.items():
+#         grouped_by_piece = defaultdict(list)
+#         for id, chunk in sliced.items():
+#             assert chunk.index.nlevels == 1
+#             assert len(id) == 3
+#             piece_id = id[:2]
+#             grouped_by_piece[piece_id].extend(chunk.duration_qb.to_list())
+#         for piece_id, durations in grouped_by_piece.items():
+#             # test if the facet slices add up to the same duration as the original facet
+#             facet_duration = sliced_data.get_item(piece_id, facet).duration_qb
+#             adds_up = math.isclose(sum(durations), facet_duration.sum())
+#             if not adds_up:
+#                 print(
+#                     f"{piece_id}: Durations for facet {facet} sum up to {facet_duration.sum()}, "
+#                     f"but the slices add up to {sum(durations)}"
+#                 )
+#     return sliced_data
+#
+#
+# @pytest.fixture(
+#     scope="session",
+# )
+# def sliced_data(apply_slicer):
+#     return apply_slicer
+#
+#
+# @pytest.fixture(
+#     scope="session",
+#     params=[
+#         CorpusGrouper(),
+#         PieceGrouper(),
+#         YearGrouper(),
+#     ],
+#     ids=["CorpusGrouper", "PieceGrouper", "YearGrouper"],
+# )
+# def grouper(request):
+#     return request.param
+#
+#
+# @pytest.fixture(
+#     scope="session",
+# )
+# def apply_grouper(grouper, corpus):
+#     grouped_data = grouper.process_data(corpus)
+#     print(f"\n{pretty_dict(grouped_data.indices)}")
+#     assert () not in grouped_data.indices
+#     lengths = [len(index_list) for index_list in grouped_data.indices.values()]
+#     assert 0 not in lengths, "Grouper has created empty groups."
+#     return grouped_data
+#
+#
+# @pytest.fixture(
+#     scope="session",
+# )
+# def grouped_data(apply_grouper):
+#     return apply_grouper
+#
+#
+# @pytest.fixture(
+#     scope="session",
+#     params=[
+#         Pipeline([LocalKeySlicer(), ModeGrouper()]),
+#         Pipeline([IsAnnotatedFilter()]),
+#     ],
+#     ids=[
+#         "ModeGrouper",
+#         "IsAnnotatedFilter",
+#     ],
+# )
+# def pipeline(request, corpus):
+#     grouped_data = request.param.process_data(corpus)
+#     print(f"\n{pretty_dict(grouped_data.indices)}")
+#     return grouped_data
+#
+#
+# @pytest.fixture(
+#     scope="session",
+# )
+# def pipelined_data(pipeline):
+#     return pipeline
+#
+#
+# @pytest.fixture(
+#     scope="session",
+#     params=[
+#         IsAnnotatedFilter(),
+#     ],
+#     ids=["IsAnnotatedFilter"],
+# )
+# def filter(request, corpus):
+#     filtered_data = request.param.process_data(corpus)
+#     print(f"\n{pretty_dict(filtered_data.indices)}")
+#     return filtered_data
 
-@pytest.fixture(
-    scope="session",
-    params=[
-        CorpusGrouper(),
-        PieceGrouper(),
-        YearGrouper(),
-    ],
-    ids=["CorpusGrouper", "PieceGrouper", "YearGrouper"],
-)
-def grouper(request):
-    return request.param
-
-
-@pytest.fixture(
-    scope="session",
-)
-def apply_grouper(grouper, corpus):
-    grouped_data = grouper.process_data(corpus)
-    print(f"\n{pretty_dict(grouped_data.indices)}")
-    assert () not in grouped_data.indices
-    lengths = [len(index_list) for index_list in grouped_data.indices.values()]
-    assert 0 not in lengths, "Grouper has created empty groups."
-    return grouped_data
-
-
-@pytest.fixture(
-    scope="session",
-)
-def grouped_data(apply_grouper):
-    return apply_grouper
-
-
-@pytest.fixture(
-    scope="session",
-    params=[
-        Pipeline([LocalKeySlicer(), ModeGrouper()]),
-        Pipeline([IsAnnotatedFilter()]),
-    ],
-    ids=[
-        "ModeGrouper",
-        "IsAnnotatedFilter",
-    ],
-)
-def pipeline(request, corpus):
-    grouped_data = request.param.process_data(corpus)
-    print(f"\n{pretty_dict(grouped_data.indices)}")
-    return grouped_data
-
-
-@pytest.fixture(
-    scope="session",
-)
-def pipelined_data(pipeline):
-    return pipeline
-
-
-@pytest.fixture(
-    scope="session",
-    params=[
-        IsAnnotatedFilter(),
-    ],
-    ids=["IsAnnotatedFilter"],
-)
-def filter(request, corpus):
-    filtered_data = request.param.process_data(corpus)
-    print(f"\n{pretty_dict(filtered_data.indices)}")
-    return filtered_data
+# endregion deprecated

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,9 +37,14 @@ RESOURCE_PATHS = {
 }
 
 
-@pytest.fixture(params=RESOURCE_PATHS.values(), ids=RESOURCE_PATHS)
+@pytest.fixture(scope="session", params=RESOURCE_PATHS.values(), ids=RESOURCE_PATHS)
 def resource_path(request):
     return request.param
+
+
+@pytest.fixture(scope="session")
+def package_path():
+    return os.path.join(CORPUS_PATH, "datapackage.json")
 
 
 def single_resource_path() -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ CORPUS_DIR = "~"
 def corpus_path():
     """Compose the paths for the test corpora."""
     print("Path was requested")
-    repo_name, test_commit = ("unittest_metacorpus", "e6fec84")
+    repo_name, test_commit = ("unittest_metacorpus", "4ce49d9")
     path = os.path.join(CORPUS_DIR, repo_name)
     path = os.path.expanduser(path)
     assert os.path.isdir(path)

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,196 +1,196 @@
-import pandas as pd
-import pytest  # noqa: F401
-from dimcat import ChordSymbolBigrams, LocalKeySlicer, PhraseSlicer, TSVWriter
-from ms3 import nan_eq
-
-__author__ = "Digital and Cognitive Musicology Lab"
-__copyright__ = "École Polytechnique Fédérale de Lausanne"
-__license__ = "GPL-3.0-or-later"
-
-
-def assert_pipeline_dependency_raise(analyzer, data):
-    if isinstance(analyzer, ChordSymbolBigrams):
-        if not any(isinstance(step, LocalKeySlicer) for step in data.pipeline_steps):
-            with pytest.raises(AssertionError):
-                _ = analyzer.process_data(data)
-            return True
-    return False
-
-
-def node_name2cfg_name(node_name):
-    """Takes 'test_function[cfg_name]' and returns 'cfg_name'."""
-    start_pos = node_name.index("[")
-    caller_name = node_name[:start_pos]
-    cfg_name = node_name[start_pos + 1 : -1]
-    return caller_name, cfg_name
-
-
-@pytest.fixture()
-def analyzer_results(request):
-    caller = request.node.originalname
-    identifier = tuple(request.node.callspec._idlist)
-    print(identifier)
-    if caller == "test_analyzer":
-        expected_results = {
-            ("TSV only", "corpus", "TPCrange", "once_per_group"): {
-                (): "pleyel_quartets-TPCrange"
-            },
-            ("TSV only", "corpus", "TPCrange", ""): {(): "pleyel_quartets-TPCrange"},
-            ("TSV only", "corpus", "PitchClassVectors", "once_per_group"): {
-                (): "pleyel_quartets-tpc-pcvs"
-            },
-            ("TSV only", "corpus", "PitchClassVectors", ""): {
-                (): "pleyel_quartets-tpc-pcvs"
-            },
-            ("TSV only", "corpus", "ChordSymbolUnigrams", "once_per_group"): {
-                (): "pleyel_quartets-ChordSymbolUnigrams"
-            },
-            ("TSV only", "corpus", "ChordSymbolUnigrams", ""): {
-                (): "pleyel_quartets-ChordSymbolUnigrams"
-            },
-            ("TSV only", "corpus", "ChordSymbolBigrams", "once_per_group"): {},
-            ("TSV only", "corpus", "ChordSymbolBigrams", ""): {},
-            ("TSV only", "metacorpus", "TPCrange", "once_per_group"): {
-                (): "all-TPCrange"
-            },
-            ("TSV only", "metacorpus", "TPCrange", ""): {(): "all-TPCrange"},
-            ("TSV only", "metacorpus", "PitchClassVectors", "once_per_group"): {
-                (): "all-tpc-pcvs"
-            },
-            ("TSV only", "metacorpus", "PitchClassVectors", ""): {(): "all-tpc-pcvs"},
-            ("TSV only", "metacorpus", "ChordSymbolUnigrams", "once_per_group"): {
-                (): "all-ChordSymbolUnigrams"
-            },
-            ("TSV only", "metacorpus", "ChordSymbolUnigrams", ""): {
-                (): "all-ChordSymbolUnigrams"
-            },
-            ("TSV only", "metacorpus", "ChordSymbolBigrams", "once_per_group"): {},
-            ("TSV only", "metacorpus", "ChordSymbolBigrams", ""): {},
-        }
-    return expected_results[identifier]
-
-
-def test_analyzer(analyzer, corpus, analyzer_results):
-    assert len(corpus.index_levels["processed"]) == 0
-    if assert_pipeline_dependency_raise(analyzer, corpus):
-        return
-    data = analyzer.process_data(corpus)
-    print(f"{data.get()}")
-    assert len(data.processed) > 0
-    assert len(data.pipeline_steps) > 0
-    automatic_filenames = TSVWriter(".").make_filenames(data)
-    assert automatic_filenames == analyzer_results
-
-
-def diff_between_series(old, new):
-    """Compares the values of two pandas.Series and computes a diff."""
-    old_l, new_l = len(old), len(new)
-    greater_length = max(old_l, new_l)
-    if old_l != new_l:
-        print(f"Old length: {old_l}, new length: {new_l}")
-        old_is_shorter = new_l == greater_length
-        shorter = old if old_is_shorter else new
-        missing_rows = abs(old_l - new_l)
-        patch = pd.Series(["missing row"] * missing_rows)
-        shorter = pd.concat([shorter, patch], ignore_index=True)
-        if old_is_shorter:
-            old = shorter
-        else:
-            new = shorter
-    old.index.rename("old_ix", inplace=True)
-    new.index.rename("new_ix", inplace=True)
-    diff = [
-        (i, o, j, n)
-        for ((i, o), (j, n)) in zip(old.iteritems(), new.iteritems())
-        if not nan_eq(o, n)
-    ]
-    n_diffs = len(diff)
-    if n_diffs > 0:
-        comparison = pd.DataFrame(diff, columns=["old_ix", "old", "new_ix", "new"])
-        print(
-            f"{n_diffs}/{greater_length} ({n_diffs / greater_length * 100:.2f} %) rows are "
-            f"different{' (showing first 20)' if n_diffs > 20 else ''}:\n{comparison}\n"
-        )
-        for a, b in zip(comparison.old.values, comparison.new.values):
-            print(a)
-            print(b)
-        return comparison
-    return pd.DataFrame()
-
-
-def test_analyzing_slices(analyzer, sliced_data):
-    if assert_pipeline_dependency_raise(analyzer, sliced_data):
-        return
-    data = analyzer.process_data(sliced_data)
-    assert len(data.slice_info) > 0
-    assert len(data.sliced) > 0
-    for facet, sliced in data.sliced.items():
-        for id, chunk in sliced.items():
-            assert chunk.index.nlevels == 1
-            try:
-                interval_lengths = pd.Series(chunk.index.length, index=chunk.index)
-            except AttributeError:
-                print(chunk)
-                raise
-            if isinstance(sliced_data.get_previous_pipeline_step(), PhraseSlicer):
-                # Currently, this test would fail for cases such as I}{ because in the resulting slices the label will
-                # appear three times:
-                # 1. as last row of the phrase ended by this label: this one will have an index interval of 0 but the
-                #    'duration_qb' of the I chord (this is what doesn't pass the test)
-                # 2. as the first two rows of the slice started by this label: once with chord = NA, index interval 0
-                #    and duration_qb = 0; once with phraseend = NA, and the chord label with its normal duration
-                continue
-            duration_column = chunk.duration_qb.astype(float)
-            diff = diff_between_series(
-                interval_lengths.round(5), duration_column.round(5)
-            )
-            if len(diff) > 0:
-                print(
-                    f"COMPARING DURATION OF INDEX INTERVALS WITH COLUMN 'duration_qb' failed for ID {id}:"
-                )
-                a = interval_lengths
-                b = chunk.index.right - chunk.index.left
-                eq = (a == b).all()
-                print("index.length == right-left:", eq)
-                print(
-                    "indices of the incongruent 'duration_qb' values:",
-                    diff.old_ix.to_list(),
-                )
-                assert False
-
-    analyzed_slices = data.get()
-    print(f"{analyzed_slices}")
-    # assert analyzed_slices.index.nlevels == 4
-
-
-def test_analyzing_groups(analyzer, grouped_data):
-    if assert_pipeline_dependency_raise(analyzer, grouped_data):
-        return
-    data = analyzer.process_data(grouped_data)
-    assert () not in data.indices
-    assert len(data.index_levels["groups"]) > 0
-    print(f"{data.get()}")
-
-
-def test_analyzing_pipelines(
-    analyzer,
-    pipelined_data,
-):
-    if assert_pipeline_dependency_raise(analyzer, pipelined_data):
-        return
-    data = analyzer.process_data(pipelined_data)
-    print(f"{data.get()}")
-
-
-def test_analyzing_grouped_pipelines(analyzer, pipelined_data, grouper):
-    grouped = grouper.process_data(pipelined_data)
-    for facet, slices in grouped.sliced.items():
-        for id, df in slices.items():
-            assert df.index.nlevels == 1
-    if assert_pipeline_dependency_raise(analyzer, grouped):
-        return
-    data = analyzer.process_data(grouped)
-    for facet, slices in data.sliced.items():
-        for id, df in slices.items():
-            assert df.index.nlevels == 1
-    print(f"{data.get()}")
+# import pandas as pd
+# import pytest  # noqa: F401
+# from dimcat import ChordSymbolBigrams, LocalKeySlicer, PhraseSlicer, TSVWriter
+# from ms3 import nan_eq
+#
+# __author__ = "Digital and Cognitive Musicology Lab"
+# __copyright__ = "École Polytechnique Fédérale de Lausanne"
+# __license__ = "GPL-3.0-or-later"
+#
+#
+# def assert_pipeline_dependency_raise(analyzer, data):
+#     if isinstance(analyzer, ChordSymbolBigrams):
+#         if not any(isinstance(step, LocalKeySlicer) for step in data.pipeline_steps):
+#             with pytest.raises(AssertionError):
+#                 _ = analyzer.process_data(data)
+#             return True
+#     return False
+#
+#
+# def node_name2cfg_name(node_name):
+#     """Takes 'test_function[cfg_name]' and returns 'cfg_name'."""
+#     start_pos = node_name.index("[")
+#     caller_name = node_name[:start_pos]
+#     cfg_name = node_name[start_pos + 1 : -1]
+#     return caller_name, cfg_name
+#
+#
+# @pytest.fixture()
+# def analyzer_results(request):
+#     caller = request.node.originalname
+#     identifier = tuple(request.node.callspec._idlist)
+#     print(identifier)
+#     if caller == "test_analyzer":
+#         expected_results = {
+#             ("TSV only", "corpus", "TPCrange", "once_per_group"): {
+#                 (): "pleyel_quartets-TPCrange"
+#             },
+#             ("TSV only", "corpus", "TPCrange", ""): {(): "pleyel_quartets-TPCrange"},
+#             ("TSV only", "corpus", "PitchClassVectors", "once_per_group"): {
+#                 (): "pleyel_quartets-tpc-pcvs"
+#             },
+#             ("TSV only", "corpus", "PitchClassVectors", ""): {
+#                 (): "pleyel_quartets-tpc-pcvs"
+#             },
+#             ("TSV only", "corpus", "ChordSymbolUnigrams", "once_per_group"): {
+#                 (): "pleyel_quartets-ChordSymbolUnigrams"
+#             },
+#             ("TSV only", "corpus", "ChordSymbolUnigrams", ""): {
+#                 (): "pleyel_quartets-ChordSymbolUnigrams"
+#             },
+#             ("TSV only", "corpus", "ChordSymbolBigrams", "once_per_group"): {},
+#             ("TSV only", "corpus", "ChordSymbolBigrams", ""): {},
+#             ("TSV only", "metacorpus", "TPCrange", "once_per_group"): {
+#                 (): "all-TPCrange"
+#             },
+#             ("TSV only", "metacorpus", "TPCrange", ""): {(): "all-TPCrange"},
+#             ("TSV only", "metacorpus", "PitchClassVectors", "once_per_group"): {
+#                 (): "all-tpc-pcvs"
+#             },
+#             ("TSV only", "metacorpus", "PitchClassVectors", ""): {(): "all-tpc-pcvs"},
+#             ("TSV only", "metacorpus", "ChordSymbolUnigrams", "once_per_group"): {
+#                 (): "all-ChordSymbolUnigrams"
+#             },
+#             ("TSV only", "metacorpus", "ChordSymbolUnigrams", ""): {
+#                 (): "all-ChordSymbolUnigrams"
+#             },
+#             ("TSV only", "metacorpus", "ChordSymbolBigrams", "once_per_group"): {},
+#             ("TSV only", "metacorpus", "ChordSymbolBigrams", ""): {},
+#         }
+#     return expected_results[identifier]
+#
+#
+# def test_analyzer(analyzer, corpus, analyzer_results):
+#     assert len(corpus.index_levels["processed"]) == 0
+#     if assert_pipeline_dependency_raise(analyzer, corpus):
+#         return
+#     data = analyzer.process_data(corpus)
+#     print(f"{data.get()}")
+#     assert len(data.processed) > 0
+#     assert len(data.pipeline_steps) > 0
+#     automatic_filenames = TSVWriter(".").make_filenames(data)
+#     assert automatic_filenames == analyzer_results
+#
+#
+# def diff_between_series(old, new):
+#     """Compares the values of two pandas.Series and computes a diff."""
+#     old_l, new_l = len(old), len(new)
+#     greater_length = max(old_l, new_l)
+#     if old_l != new_l:
+#         print(f"Old length: {old_l}, new length: {new_l}")
+#         old_is_shorter = new_l == greater_length
+#         shorter = old if old_is_shorter else new
+#         missing_rows = abs(old_l - new_l)
+#         patch = pd.Series(["missing row"] * missing_rows)
+#         shorter = pd.concat([shorter, patch], ignore_index=True)
+#         if old_is_shorter:
+#             old = shorter
+#         else:
+#             new = shorter
+#     old.index.rename("old_ix", inplace=True)
+#     new.index.rename("new_ix", inplace=True)
+#     diff = [
+#         (i, o, j, n)
+#         for ((i, o), (j, n)) in zip(old.iteritems(), new.iteritems())
+#         if not nan_eq(o, n)
+#     ]
+#     n_diffs = len(diff)
+#     if n_diffs > 0:
+#         comparison = pd.DataFrame(diff, columns=["old_ix", "old", "new_ix", "new"])
+#         print(
+#             f"{n_diffs}/{greater_length} ({n_diffs / greater_length * 100:.2f} %) rows are "
+#             f"different{' (showing first 20)' if n_diffs > 20 else ''}:\n{comparison}\n"
+#         )
+#         for a, b in zip(comparison.old.values, comparison.new.values):
+#             print(a)
+#             print(b)
+#         return comparison
+#     return pd.DataFrame()
+#
+#
+# def test_analyzing_slices(analyzer, sliced_data):
+#     if assert_pipeline_dependency_raise(analyzer, sliced_data):
+#         return
+#     data = analyzer.process_data(sliced_data)
+#     assert len(data.slice_info) > 0
+#     assert len(data.sliced) > 0
+#     for facet, sliced in data.sliced.items():
+#         for id, chunk in sliced.items():
+#             assert chunk.index.nlevels == 1
+#             try:
+#                 interval_lengths = pd.Series(chunk.index.length, index=chunk.index)
+#             except AttributeError:
+#                 print(chunk)
+#                 raise
+#             if isinstance(sliced_data.get_previous_pipeline_step(), PhraseSlicer):
+#                 # Currently, this test would fail for cases such as I}{ because in the resulting slices the label will
+#                 # appear three times:
+#                 # 1. as last row of the phrase ended by this label: this one will have an index interval of 0 but the
+#                 #    'duration_qb' of the I chord (this is what doesn't pass the test)
+#                 # 2. as the first two rows of the slice started by this label: once with chord = NA, index interval 0
+#                 #    and duration_qb = 0; once with phraseend = NA, and the chord label with its normal duration
+#                 continue
+#             duration_column = chunk.duration_qb.astype(float)
+#             diff = diff_between_series(
+#                 interval_lengths.round(5), duration_column.round(5)
+#             )
+#             if len(diff) > 0:
+#                 print(
+#                     f"COMPARING DURATION OF INDEX INTERVALS WITH COLUMN 'duration_qb' failed for ID {id}:"
+#                 )
+#                 a = interval_lengths
+#                 b = chunk.index.right - chunk.index.left
+#                 eq = (a == b).all()
+#                 print("index.length == right-left:", eq)
+#                 print(
+#                     "indices of the incongruent 'duration_qb' values:",
+#                     diff.old_ix.to_list(),
+#                 )
+#                 assert False
+#
+#     analyzed_slices = data.get()
+#     print(f"{analyzed_slices}")
+#     # assert analyzed_slices.index.nlevels == 4
+#
+#
+# def test_analyzing_groups(analyzer, grouped_data):
+#     if assert_pipeline_dependency_raise(analyzer, grouped_data):
+#         return
+#     data = analyzer.process_data(grouped_data)
+#     assert () not in data.indices
+#     assert len(data.index_levels["groups"]) > 0
+#     print(f"{data.get()}")
+#
+#
+# def test_analyzing_pipelines(
+#     analyzer,
+#     pipelined_data,
+# ):
+#     if assert_pipeline_dependency_raise(analyzer, pipelined_data):
+#         return
+#     data = analyzer.process_data(pipelined_data)
+#     print(f"{data.get()}")
+#
+#
+# def test_analyzing_grouped_pipelines(analyzer, pipelined_data, grouper):
+#     grouped = grouper.process_data(pipelined_data)
+#     for facet, slices in grouped.sliced.items():
+#         for id, df in slices.items():
+#             assert df.index.nlevels == 1
+#     if assert_pipeline_dependency_raise(analyzer, grouped):
+#         return
+#     data = analyzer.process_data(grouped)
+#     for facet, slices in data.sliced.items():
+#         for id, df in slices.items():
+#             assert df.index.nlevels == 1
+#     print(f"{data.get()}")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,7 +7,6 @@ from itertools import product
 from pprint import pprint
 from typing import Iterable, List, Tuple, Type
 
-import frictionless as fl
 import pytest
 from dimcat.analyzers import Counter
 from dimcat.analyzers.base import Analyzer
@@ -22,14 +21,12 @@ from dimcat.base import (
     deserialize_json_str,
 )
 from dimcat.dataset.base import DimcatPackage
-from dimcat.resources.base import DimcatResource, ResourceStatus
+from dimcat.resources.base import DimcatResource
 from dimcat.resources.features import Notes
-from git import Repo
 from marshmallow import ValidationError, fields, pre_load, validate
 from marshmallow.class_registry import _registry as MM_REGISTRY
 
-# Directory holding your clones of DCMLab/unittest_metacorpus
-CORPUS_DIR = "~"
+from tests.conftest import datapackage_json_path, single_resource_path
 
 
 class DummyAnalyzer(PipelineStep):
@@ -82,36 +79,6 @@ def test_dummy_analyzer():
     config = DimcatConfig(dtype="DimcatObject")
     report = DummyAnalyzer.schema.validate({"features": [config]})
     assert len(report) == 0
-
-
-def corpus_path():
-    """Compose the paths for the test corpora."""
-    print("Path was requested")
-    repo_name, test_commit = ("unittest_metacorpus", "e6fec84")
-    path = os.path.join(CORPUS_DIR, repo_name)
-    path = os.path.expanduser(path)
-    assert os.path.isdir(path)
-    repo = Repo(path)
-    commit = repo.commit("HEAD")
-    sha = commit.hexsha[: len(test_commit)]
-    assert (
-        sha == test_commit
-    ), f"Your {path} is @ {sha}. Please do\n\tgit checkout {test_commit}."
-    return path
-
-
-CORPUS_PATH = corpus_path()
-
-RESOURCE_PATHS = {
-    file: os.path.join(CORPUS_PATH, file)
-    for file in os.listdir(CORPUS_PATH)
-    if file.endswith(".resource.yaml")
-}
-
-
-@pytest.fixture(params=RESOURCE_PATHS.values(), ids=RESOURCE_PATHS)
-def resource_path(request):
-    return request.param
 
 
 class TestBaseObjects:
@@ -180,16 +147,6 @@ DUMMY_CONFIG_OPTIONS = dict(dtype="Notes")
 def dummy_config() -> DimcatConfig:
     """Returns a dummy config for use in the test cases."""
     return DimcatConfig(**DUMMY_CONFIG_OPTIONS)
-
-
-def single_resource_path() -> str:
-    """Returns the path to a single resource."""
-    return RESOURCE_PATHS["unittest_notes.resource.yaml"]
-
-
-def datapackage_json_path() -> str:
-    """Returns the path to a single resource."""
-    return os.path.join(CORPUS_PATH, "datapackage.json")
 
 
 DIMCAT_OBJECT_TEST_CASES: List[Tuple[Type[DimcatObject], dict]] = [
@@ -298,65 +255,6 @@ class TestSerialization:
             self.dimcat_object.to_json_file(tmp_file.name)
             new_object = deserialize_json_file(tmp_file.name)
         assert new_object == self.dimcat_object
-
-
-class TestResource:
-    @pytest.fixture()
-    def resource_from_descriptor(self, resource_path):
-        resource = DimcatResource(resource=resource_path)
-        return resource
-
-    @pytest.fixture()
-    def resource_schema(self, resource_path):
-        res = fl.Resource(resource_path)
-        return res.schema
-
-    @pytest.fixture()
-    def as_dict(self, resource_from_descriptor):
-        return resource_from_descriptor.to_dict()
-
-    @pytest.fixture()
-    def as_config(self, resource_from_descriptor):
-        return resource_from_descriptor.to_config()
-
-    @pytest.fixture()
-    def resource_dataframe(self, resource_from_descriptor):
-        return resource_from_descriptor.get_dataframe()
-
-    @pytest.fixture()
-    def resource_from_dataframe(self, resource_dataframe, resource_schema):
-        return DimcatResource(df=resource_dataframe, column_schema=resource_schema)
-
-    def test_resource_from_disk(self, resource_from_descriptor):
-        assert resource_from_descriptor.status == ResourceStatus.ON_DISK_NOT_LOADED
-        print(resource_from_descriptor.__dict__)
-        with pytest.raises(RuntimeError):
-            resource_from_descriptor.basepath = "~"
-
-    def test_resource_from_df(self, resource_from_dataframe):
-        print(resource_from_dataframe)
-        assert resource_from_dataframe.status in (
-            ResourceStatus.VALIDATED,
-            ResourceStatus.DATAFRAME,
-        )
-        as_config = resource_from_dataframe.to_config()
-        print(as_config)
-        os.remove(resource_from_dataframe.normpath)
-
-    def test_serialization(self, as_dict, as_config):
-        print(as_dict)
-        print(as_config)
-        assert as_dict == as_config
-
-    def test_deserialization_via_config(self, as_dict, as_config):
-        dc_config = DimcatConfig(as_dict)
-        print(dc_config.dtype)
-        print(dc_config.schema)
-        from_dict = dc_config.create()
-        assert isinstance(from_dict, DimcatResource)
-        from_config = as_config.create()
-        assert isinstance(from_config, DimcatResource)
-        assert from_dict.__dict__.keys() == from_config.__dict__.keys()
 
 
 # BELOW IS PLAYGROUND CODE WAITING TO BE FACTORED IN

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -156,7 +156,10 @@ DIMCAT_OBJECT_TEST_CASES: List[Tuple[Type[DimcatObject], dict]] = [
     (Data, {}),
     (PipelineStep, {}),
     (DimcatConfig, dummy_config()),
-    (DimcatResource, dict(resource=fl.Resource(name="empty_resource"))),
+    (
+        DimcatResource,
+        dict(resource=fl.Resource(name="empty_resource", path="empty_resource.tsv")),
+    ),
     (DummyAnalyzer, dict(features=dummy_config())),
     (Notes, dict(resource=single_resource_path())),
     (Analyzer, dict(features=dummy_config())),

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,6 +7,7 @@ from itertools import product
 from pprint import pprint
 from typing import Iterable, List, Tuple, Type
 
+import pandas as pd
 import pytest
 from dimcat.analyzers import Counter
 from dimcat.analyzers.base import Analyzer
@@ -20,13 +21,13 @@ from dimcat.base import (
     deserialize_json_file,
     deserialize_json_str,
 )
-from dimcat.dataset.base import DimcatPackage
+from dimcat.dataset.base import DimcatCatalog
 from dimcat.resources.base import DimcatResource
 from dimcat.resources.features import Notes
 from marshmallow import ValidationError, fields, pre_load, validate
 from marshmallow.class_registry import _registry as MM_REGISTRY
 
-from tests.conftest import datapackage_json_path, single_resource_path
+from tests.conftest import single_resource_path
 
 
 class DummyAnalyzer(PipelineStep):
@@ -159,8 +160,7 @@ DIMCAT_OBJECT_TEST_CASES: List[Tuple[Type[DimcatObject], dict]] = [
     (Notes, dict(resource=single_resource_path())),
     (Analyzer, dict(features=dummy_config())),
     (Counter, dict(features=dummy_config())),
-    (DimcatPackage, dict(package=dict(name="fun_package"))),
-    (DimcatPackage, dict(package=datapackage_json_path())),
+    (DimcatCatalog, {}),
 ]
 
 
@@ -176,7 +176,9 @@ def arg_val2str(val) -> str:
         return os.path.basename(val)
     if isinstance(val, dict):
         return f"{{{kwargs2str(val)}}}"
-    return str(val)
+    if isinstance(val, pd.DataFrame):
+        return "[DataFrame]"
+    return f"{val!r}"
 
 
 def kwargs2str(options):
@@ -197,12 +199,17 @@ def make_test_id(params: tuple) -> str:
     params=DIMCAT_OBJECT_TEST_CASES,
     ids=make_test_id,
 )
-def dimcat_object(request):
+def dimcat_object(request, tmp_path_factory):
     """Initializes each of the objects to be tested and injects them into the test class."""
     Constructor, options = unpack_dimcat_object_params(request.param)
     request.cls.dtype = Constructor
+    dimcat_object = Constructor(**options)
+    if isinstance(dimcat_object, DimcatResource) and not dimcat_object.is_frozen:
+        tmp_path = tmp_path_factory.mktemp("dimcat_resource")
+        dimcat_object.basepath = tmp_path
+        options["basepath"] = tmp_path
+    request.cls.dimcat_object = dimcat_object
     request.cls.options = options
-    request.cls.dimcat_object = Constructor(**options)
 
 
 @pytest.mark.usefixtures("dimcat_object")
@@ -230,10 +237,18 @@ class TestSerialization:
     def test_creation_from_config(self):
         config = self.dimcat_object.to_config()
         new_object = config.create()
+        a = new_object.to_dict()
+        b = self.dimcat_object.to_dict()
+        print(a, type(a))
+        print(b, type(b))
         assert new_object == self.dimcat_object
 
     def test_creation_from_manual_config(self):
-        config = DimcatConfig(dtype=self.dtype.name, options=self.options)
+        options = dict(self.options)
+        if "basepath" in options:
+            tmp_path = options.pop("basepath")
+            os.chdir(tmp_path)
+        config = DimcatConfig(dtype=self.dtype.name, options=options)
         new_object = config.create()
         assert new_object == self.dimcat_object
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,6 +7,7 @@ from itertools import product
 from pprint import pprint
 from typing import Iterable, List, Tuple, Type
 
+import frictionless as fl
 import pandas as pd
 import pytest
 from dimcat.analyzers import Counter
@@ -21,13 +22,13 @@ from dimcat.base import (
     deserialize_json_file,
     deserialize_json_str,
 )
-from dimcat.dataset.base import DimcatCatalog
+from dimcat.dataset.base import DimcatCatalog, DimcatPackage
 from dimcat.resources.base import DimcatResource
 from dimcat.resources.features import Notes
 from marshmallow import ValidationError, fields, pre_load, validate
 from marshmallow.class_registry import _registry as MM_REGISTRY
 
-from tests.conftest import single_resource_path
+from tests.conftest import datapackage_json_path, single_resource_path
 
 
 class DummyAnalyzer(PipelineStep):
@@ -155,11 +156,12 @@ DIMCAT_OBJECT_TEST_CASES: List[Tuple[Type[DimcatObject], dict]] = [
     (Data, {}),
     (PipelineStep, {}),
     (DimcatConfig, dummy_config()),
-    (DimcatResource, dict(resource=single_resource_path())),
+    (DimcatResource, dict(resource=fl.Resource(name="empty_resource"))),
     (DummyAnalyzer, dict(features=dummy_config())),
     (Notes, dict(resource=single_resource_path())),
     (Analyzer, dict(features=dummy_config())),
     (Counter, dict(features=dummy_config())),
+    (DimcatPackage, dict(package=datapackage_json_path())),
     (DimcatCatalog, {}),
 ]
 
@@ -237,8 +239,8 @@ class TestSerialization:
     def test_creation_from_config(self):
         config = self.dimcat_object.to_config()
         new_object = config.create()
-        a = new_object.to_dict()
-        b = self.dimcat_object.to_dict()
+        a = self.dimcat_object.to_dict()
+        b = new_object.to_dict()
         print(a, type(a))
         print(b, type(b))
         assert new_object == self.dimcat_object

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -6,6 +6,8 @@ from dimcat.resources.base import DimcatResource, ResourceStatus, get_default_ba
 
 from tests.conftest import CORPUS_PATH
 
+# region helper fixtures
+
 
 @pytest.fixture(scope="session")
 def fl_resource(resource_path):
@@ -42,11 +44,15 @@ def empty_resource():
     return DimcatResource(resource_name="empty_resource")
 
 
+# endregion helper fixtures
+
+
 class TestVanillaResource:
     expected_resource_status: ResourceStatus = ResourceStatus.EMPTY
     """The expected status of the resource after initialization."""
     should_be_frozen: bool = False
     """Whether the resource should be frozen, i.e., immutable after initialization."""
+    should_be_serialized: bool = False
 
     @pytest.fixture()
     def expected_basepath(self):
@@ -73,6 +79,9 @@ class TestVanillaResource:
         assert report is None or report.valid
         assert dc_resource.is_valid
 
+    def test_serialized(self, dc_resource):
+        assert dc_resource.is_serialized == self.should_be_serialized
+
 
 @pytest.fixture(scope="session")
 def resource_from_descriptor(resource_path):
@@ -83,6 +92,7 @@ def resource_from_descriptor(resource_path):
 class TestDiskResource(TestVanillaResource):
     expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
     should_be_frozen: bool = True
+    should_be_serialized = True
 
     @pytest.fixture()
     def expected_basepath(self):
@@ -183,6 +193,7 @@ def serialized_resource(resource_from_dataframe) -> DimcatResource:
 class TestSerializedResource(TestMemoryResource):
     expected_resource_status = ResourceStatus.ON_DISK_AND_LOADED
     should_be_frozen: bool = True
+    should_be_serialized = True
 
     @pytest.fixture()
     def dc_resource(self, serialized_resource):
@@ -318,10 +329,6 @@ class TestFromDcPackage(TestDiskResource):
 #         assert self.resource_from_descriptor == self.resource_from_fl_resource
 #         assert self.resource_from_descriptor == self.resource_from_dataframe
 #
-#     def test_is_serialized(self):
-#         assert self.resource_from_descriptor.is_serialized
-#         assert self.resource_from_fl_resource.is_serialized
-#         assert not self.resource_from_dataframe.is_serialized
 #
 #     def test_is_loaded(self):
 #         assert not self.resource_from_descriptor.is_loaded

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -111,6 +111,18 @@ class TestDiskResource(TestVanillaResource):
 
 
 @pytest.fixture(scope="session")
+def resource_from_frozen_resource(resource_from_descriptor):
+    """Returns a DimcatResource object created from a frozen resource."""
+    return DimcatResource.from_resource(resource_from_descriptor)
+
+
+class TestResourceFromFrozen(TestDiskResource):
+    @pytest.fixture()
+    def dc_resource(self, resource_from_frozen_resource):
+        return resource_from_frozen_resource
+
+
+@pytest.fixture(scope="session")
 def empty_resource_with_paths(tmp_serialization_path):
     return DimcatResource(
         basepath=tmp_serialization_path, filepath="empty_resource.tsv"
@@ -173,6 +185,18 @@ class TestFromDataFrame(TestMemoryResource):
     @pytest.fixture()
     def dc_resource(self, resource_from_dataframe) -> DimcatResource:
         return resource_from_dataframe
+
+
+@pytest.fixture(scope="session")
+def resource_from_memory_resource(resource_from_dataframe):
+    """Returns a DimcatResource object created from a frozen resource."""
+    return DimcatResource.from_resource(resource_from_dataframe)
+
+
+class TestResourceFromMemoryResource(TestFromDataFrame):
+    @pytest.fixture()
+    def dc_resource(self, resource_from_memory_resource):
+        return resource_from_memory_resource
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,62 +1,379 @@
-import os
-
 import frictionless as fl
+import ms3
 import pytest
-from dimcat.base import deserialize_dict
-from dimcat.resources.base import DimcatResource, ResourceStatus
+from dimcat.dataset import DimcatPackage
+from dimcat.resources.base import DimcatResource, ResourceStatus, get_default_basepath
+
+from tests.conftest import CORPUS_PATH
 
 
-class TestResource:
+@pytest.fixture(scope="session")
+def fl_resource(resource_path):
+    """Returns a frictionless resource object."""
+    return fl.Resource(resource_path)
+
+
+@pytest.fixture(scope="session")
+def fl_package(package_path) -> fl.Package:
+    """Returns a frictionless package object."""
+    return fl.Package(package_path)
+
+
+@pytest.fixture(scope="session")
+def dc_package(fl_package) -> DimcatPackage:
+    """Returns a DimcatPackage object."""
+    return DimcatPackage(fl_package)
+
+
+@pytest.fixture(scope="session")
+def dataframe_from_tsv(fl_resource):
+    """Returns a dataframe read directly from the normpath of the fl_resource."""
+    return ms3.load_tsv(fl_resource.normpath)
+
+
+@pytest.fixture(scope="session")
+def tmp_serialization_path(tmp_path_factory, fl_resource):
+    """Returns the path to the directory where serialized resources are stored."""
+    return str(tmp_path_factory.mktemp(fl_resource.name))
+
+
+@pytest.fixture(scope="session")
+def empty_resource():
+    return DimcatResource(resource_name="empty_resource")
+
+
+class TestVanillaResource:
+    expected_resource_status: ResourceStatus = ResourceStatus.EMPTY
+    """The expected status of the resource after initialization."""
+
     @pytest.fixture()
-    def resource_from_descriptor(self, resource_path):
-        resource = DimcatResource(resource=resource_path)
-        return resource
+    def expected_basepath(self):
+        """The expected basepath of the resource after initialization."""
+        return get_default_basepath()
 
     @pytest.fixture()
-    def resource_schema(self, resource_path):
-        res = fl.Resource(resource_path)
-        return res.schema
+    def dc_resource(self, empty_resource):
+        """For each subclass of TestVanillaResource, this fixture should be overridden and yield the
+        tested DimcatResource object."""
+        return empty_resource
+
+    def test_basepath_after_init(self, dc_resource, expected_basepath):
+        assert dc_resource.basepath == expected_basepath
+
+    def test_status_after_init(self, dc_resource):
+        assert dc_resource.status == self.expected_resource_status
+
+
+@pytest.fixture(scope="session")
+def resource_from_descriptor(resource_path):
+    """Returns a DimcatResource object created from the descriptor on disk."""
+    return DimcatResource.from_descriptor(descriptor_path=resource_path)
+
+
+class TestDiskResource(TestVanillaResource):
+    expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
 
     @pytest.fixture()
-    def as_dict(self, resource_from_descriptor):
-        return resource_from_descriptor.to_dict()
+    def expected_basepath(self):
+        return CORPUS_PATH
 
     @pytest.fixture()
-    def as_config(self, resource_from_descriptor):
-        return resource_from_descriptor.to_config()
+    def dc_resource(self, resource_from_descriptor):
+        return resource_from_descriptor
+
+
+@pytest.fixture(scope="session")
+def empty_resource_with_paths(tmp_serialization_path):
+    return DimcatResource(
+        basepath=tmp_serialization_path, filepath="empty_resource.tsv"
+    )
+
+
+class TestMemoryResource(TestVanillaResource):
+    @pytest.fixture()
+    def expected_basepath(self, tmp_serialization_path):
+        return tmp_serialization_path
 
     @pytest.fixture()
-    def resource_dataframe(self, resource_from_descriptor):
-        return resource_from_descriptor.get_dataframe()
+    def dc_resource(self, empty_resource_with_paths):
+        return empty_resource_with_paths
+
+
+@pytest.fixture(scope="session")
+def schema_resource(fl_resource):
+    """Returns a DimcatResource with a pre-set frictionless.Schema object."""
+    return DimcatResource(column_schema=fl_resource.schema)
+
+
+class TestSchemaResource(TestVanillaResource):
+    expected_resource_status = ResourceStatus.SCHEMA
 
     @pytest.fixture()
-    def resource_from_dataframe(self, resource_dataframe, resource_schema):
-        return DimcatResource(df=resource_dataframe, column_schema=resource_schema)
+    def dc_resource(self, schema_resource) -> DimcatResource:
+        return schema_resource
 
-    def test_resource_from_disk(self, resource_from_descriptor):
-        assert resource_from_descriptor.status == ResourceStatus.ON_DISK_NOT_LOADED
-        print(resource_from_descriptor.__dict__)
-        with pytest.raises(RuntimeError):
-            resource_from_descriptor.basepath = "~"
 
-    def test_resource_from_df(self, resource_from_dataframe):
-        print(resource_from_dataframe)
-        assert resource_from_dataframe.status in (
-            ResourceStatus.VALIDATED,
-            ResourceStatus.DATAFRAME,
-        )
-        as_config = resource_from_dataframe.to_config()
-        print(as_config)
-        os.remove(resource_from_dataframe.normpath)
+@pytest.fixture(scope="session")
+def resource_from_dataframe(
+    dataframe_from_tsv, fl_resource, tmp_serialization_path
+) -> DimcatResource:
+    """Returns a DimcatResource object created from the dataframe."""
+    return DimcatResource.from_dataframe(
+        df=dataframe_from_tsv,
+        resource_name=fl_resource.name,
+        basepath=tmp_serialization_path,
+        column_schema=fl_resource.schema,
+    )
 
-    def test_serialization(self, as_dict, as_config):
-        print(as_dict)
-        print(as_config)
-        assert as_dict == as_config
 
-    def test_deserialization_via_config(self, as_dict, as_config):
-        from_dict = deserialize_dict(as_dict)
-        assert isinstance(from_dict, DimcatResource)
-        from_config = as_config.create()
-        assert isinstance(from_config, DimcatResource)
-        assert from_dict.__dict__.keys() == from_config.__dict__.keys()
+class TestFromDataFrame(TestMemoryResource):
+    expected_resource_status = ResourceStatus.DATAFRAME
+
+    @pytest.fixture()
+    def dc_resource(self, resource_from_dataframe) -> DimcatResource:
+        return resource_from_dataframe
+
+
+@pytest.fixture(scope="session")
+def assembled_resource(
+    dataframe_from_tsv, fl_resource, tmp_serialization_path
+) -> DimcatResource:
+    resource = DimcatResource(
+        resource_name=fl_resource.name, column_schema=fl_resource.schema
+    )
+    resource.df = dataframe_from_tsv
+    resource.basepath = tmp_serialization_path
+    return resource
+
+
+class TestAssembledResource(TestMemoryResource):
+    expected_resource_status = ResourceStatus.DATAFRAME
+
+    @pytest.fixture()
+    def dc_resource(self, assembled_resource):
+        return assembled_resource
+
+
+@pytest.fixture(scope="session")
+def serialized_resource(resource_from_dataframe) -> DimcatResource:
+    resource_from_dataframe.store_dataframe()
+    return resource_from_dataframe
+
+
+class TestSerializedResource(TestMemoryResource):
+    expected_resource_status = ResourceStatus.ON_DISK_AND_LOADED
+
+    @pytest.fixture()
+    def dc_resource(self, serialized_resource):
+        return serialized_resource
+
+
+@pytest.fixture(scope="session")
+def resource_from_fl_resource(fl_resource) -> DimcatResource:
+    """Returns a Dimcat resource object created from the frictionless.Resource object."""
+    return DimcatResource(resource=fl_resource)
+
+
+class TestFromFrictionless(TestDiskResource):
+    expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+
+    @pytest.fixture()
+    def dc_resource(self, resource_from_fl_resource):
+        return resource_from_fl_resource
+
+
+@pytest.fixture(scope="session")
+def resource_from_dict(resource_from_descriptor):
+    """Returns a DimcatResource object created from the descriptor source."""
+    as_dict = resource_from_descriptor.to_dict()
+    return DimcatResource.from_dict(as_dict)
+
+
+class TestFromDict(TestDiskResource):
+    expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+
+    @pytest.fixture()
+    def dc_resource(self, resource_from_dict):
+        return resource_from_dict
+
+
+@pytest.fixture(scope="session")
+def resource_from_config(resource_from_descriptor):
+    """Returns a DimcatResource object created from the descriptor on disk."""
+    config = resource_from_descriptor.to_config()
+    return DimcatResource.from_config(config)
+
+
+class TestFromConfig(TestDiskResource):
+    expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+
+    @pytest.fixture()
+    def dc_resource(self, resource_from_config):
+        return resource_from_config
+
+
+@pytest.fixture(scope="session")
+def zipped_resource_from_fl_package(fl_package) -> DimcatResource:
+    """Returns a DimcatResource object created from the dataframe."""
+    fl_resource = fl_package.get_resource("notes")
+    return DimcatResource(resource=fl_resource)
+
+
+class TestFromFlPackage(TestDiskResource):
+    expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+
+    @pytest.fixture()
+    def dc_resource(self, zipped_resource_from_fl_package):
+        return zipped_resource_from_fl_package
+
+
+@pytest.fixture(scope="session")
+def zipped_resource_from_dc_package(dc_package) -> DimcatResource:
+    dc_resource = dc_package.get_resource("notes")
+    return DimcatResource.from_resource(dc_resource)
+
+
+class TestFromDcPackage(TestDiskResource):
+    expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+
+    @pytest.fixture()
+    def dc_resource(self, zipped_resource_from_dc_package):
+        return zipped_resource_from_dc_package
+
+
+#
+# @pytest.fixture(
+#     scope="class",
+# )
+# def dimcat_resource(request,
+#                     resource_path,
+#                     fl_resource,
+#                     resource_from_descriptor,
+#                     resource_from_fl_resource,
+#                     resource_from_dict,
+#                     resource_from_config,
+#                     dataframe_from_tsv,
+#                     resource_from_dataframe,
+#                     tmp_serialization_path):
+#     """Initializes each of the resource objects to be tested and injects them into the test class."""
+#     request.cls.tmp_path = tmp_serialization_path
+#     request.cls.descriptor_path = resource_path
+#     request.cls.fl_resource = fl_resource
+#     request.cls.resource_from_descriptor = resource_from_descriptor
+#     request.cls.resource_from_fl_resource = resource_from_fl_resource
+#     request.cls.dataframe_from_tsv = dataframe_from_tsv
+#     request.cls.resource_from_dataframe = resource_from_dataframe
+#     request.cls.resource_from_dict = resource_from_dict
+#     request.cls.resource_from_config = resource_from_config
+#
+#
+#
+#
+# @pytest.mark.usefixtures("dimcat_resource")
+# class TestResourceOld:
+#     """Each method uses the same objects, and therefore should restore their original status after
+#     changing it."""
+#
+#     tmp_path: str
+#     """Path to the temporary directory where not-frozen test resources are stored during serialization."""
+#     descriptor_path: str
+#     """Path to the JSON resource descriptor on disk."""
+#     fl_resource: fl.Resource
+#     """Frictionless resource object created from the descriptor on disk."""
+#     resource_from_descriptor: DimcatResource
+#     """DimcatResource object created from the descriptor on disk."""
+#     resource_from_fl_resource: DimcatResource
+#     """Dimcat resource object created from the frictionless.Resource object."""
+#     dataframe_from_tsv: pd.DataFrame
+#     """Pandas dataframe created from the TSV file described by the resource."""
+#     resource_from_dataframe: DimcatResource
+#     """Dimcat resource object created from the dataframe."""
+#     resource_from_dict: DimcatResource
+#     """Dimcat resource object created from the descriptor source."""
+#     resource_from_config: DimcatResource
+#     """Dimcat resource object created from a serialized ."""
+#
+#     def test_equivalence(self):
+#         assert self.resource_from_descriptor == self.resource_from_fl_resource
+#         assert self.resource_from_descriptor == self.resource_from_dataframe
+#
+
+#     def test_is_frozen(self):
+#         assert self.resource_from_descriptor.is_frozen
+#         assert self.resource_from_fl_resource.is_frozen
+#         assert not self.resource_from_dataframe.is_frozen
+#
+#     def test_is_valid(self):
+#         assert self.resource_from_descriptor.is_valid
+#         assert self.resource_from_fl_resource.is_valid
+#         assert not self.resource_from_dataframe.is_valid # currently, schema corresponds to types in TSV not loaded df
+#
+#     def test_is_serialized(self):
+#         assert self.resource_from_descriptor.is_serialized
+#         assert self.resource_from_fl_resource.is_serialized
+#         assert not self.resource_from_dataframe.is_serialized
+#
+#     def test_is_loaded(self):
+#         assert not self.resource_from_descriptor.is_loaded
+#         assert not self.resource_from_fl_resource.is_loaded
+#         assert self.resource_from_dataframe.is_loaded
+#
+#     def test_descriptor_path(self):
+#         assert self.resource_from_descriptor.descriptor_path == self.descriptor_path
+#         assert self.resource_from_fl_resource.descriptor_path is None
+#         assert self.resource_from_dataframe.descriptor_path is None
+#
+#     def test_basepath(self):
+#         assert self.resource_from_descriptor.basepath == os.path.dirname(self.descriptor_path)
+#         assert self.resource_from_fl_resource.basepath == os.path.dirname(self.descriptor_path)
+#         assert self.resource_from_dataframe.basepath == self.tmp_path
+#         with pytest.raises(RuntimeError):
+#             self.resource_from_descriptor.basepath = "~"
+#         with pytest.raises(RuntimeError):
+#             self.resource_from_fl_resource.basepath = "~"
+#         self.resource_from_dataframe.basepath = "~"
+#         assert self.resource_from_dataframe.basepath == os.path.expanduser("~")
+#         self.resource_from_dataframe.basepath = self.tmp_path
+#
+#     def test_filepath(self):
+#         assert self.resource_from_descriptor.filepath == self.resource_from_descriptor.resource_name + ".tsv"
+#         assert self.resource_from_fl_resource.filepath == self.resource_from_fl_resource.resource_name + ".tsv"
+#         assert self.resource_from_dataframe.filepath == self.fl_resource.name + ".tsv"
+#         with pytest.raises(RuntimeError):
+#             self.resource_from_descriptor.filepath = "test.tsv"
+#         with pytest.raises(RuntimeError):
+#             self.resource_from_fl_resource.filepath = "test.tsv"
+#         self.resource_from_dataframe.filepath = "subfolder/test.tsv"
+#         assert self.resource_from_dataframe.normpath == os.path.join(self.tmp_path, "subfolder", "test.tsv")
+#
+#     def test_store_dataframe(self):
+#         """"""
+#         ms3.assert_dfs_equal(self.resource_from_descriptor.df, self.dataframe_from_tsv)
+#         ms3.assert_dfs_equal(self.resource_from_fl_resource.df, self.dataframe_from_tsv)
+#         config = self.resource_from_dataframe.to_config()
+#         fresh_copy = config.create()
+#         ms3.assert_dfs_equal(fresh_copy.df, self.dataframe_from_tsv)
+#
+#
+#
+#     def test_resource_from_df(self):
+#         print(self.resource_from_dataframe)
+#         assert self.resource_from_dataframe.status in (
+#             ResourceStatus.VALIDATED,
+#             ResourceStatus.DATAFRAME,
+#         )
+#         as_config = self.resource_from_dataframe.to_config()
+#         print(as_config)
+#
+#     def test_serialization(self, as_dict, as_config):
+#         print(as_dict)
+#         print(as_config)
+#         assert as_dict == as_config
+#
+#     def test_deserialization_via_config(self, as_dict, as_config):
+#         from_dict = deserialize_dict(as_dict)
+#         assert isinstance(from_dict, DimcatResource)
+#         from_config = as_config.create()
+#         assert isinstance(from_config, DimcatResource)
+#         assert from_dict.__dict__.keys() == from_config.__dict__.keys()
+#

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -12,13 +12,13 @@ from tests.conftest import CORPUS_PATH
 # region helper fixtures
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def fl_resource(resource_path):
     """Returns a frictionless resource object."""
     return fl.Resource(resource_path)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def dataframe_from_tsv(fl_resource):
     """Returns a dataframe read directly from the normpath of the fl_resource."""
     return ms3.load_tsv(fl_resource.normpath)
@@ -104,7 +104,7 @@ def resource_from_descriptor(resource_path):
 
 
 class TestDiskResource(TestVanillaResource):
-    expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+    expected_resource_status = ResourceStatus.STANDALONE_NOT_LOADED
     should_be_frozen: bool = True
     should_be_serialized = True
     should_have_descriptor = True
@@ -185,7 +185,6 @@ def resource_from_dataframe(
         resource_name=fl_resource.name,
         basepath=tmp_serialization_path,
         column_schema=fl_resource.schema,
-        auto_validate=False,
     )
 
 
@@ -217,7 +216,6 @@ def assembled_resource(
     resource = DimcatResource(
         basepath=tmp_serialization_path,
         resource_name=fl_resource.name,
-        auto_validate=False,
     )
     resource.df = dataframe_from_tsv
     return resource
@@ -239,7 +237,7 @@ def serialized_resource(resource_from_dataframe) -> DimcatResource:
 
 
 class TestSerializedResource(TestMemoryResource):
-    expected_resource_status = ResourceStatus.ON_DISK_AND_LOADED
+    expected_resource_status = ResourceStatus.STANDALONE_LOADED
     should_be_frozen: bool = True
     should_be_serialized = True
     should_be_loaded = True
@@ -261,7 +259,7 @@ def resource_from_fl_resource(
 
 
 class TestFromFrictionless(TestDiskResource):
-    expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+    expected_resource_status = ResourceStatus.STANDALONE_NOT_LOADED
 
     @pytest.fixture()
     def dc_resource(self, resource_from_fl_resource):
@@ -276,7 +274,7 @@ def resource_from_dict(resource_from_descriptor):
 
 
 class TestFromDict(TestDiskResource):
-    expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+    expected_resource_status = ResourceStatus.STANDALONE_NOT_LOADED
 
     @pytest.fixture()
     def dc_resource(self, resource_from_dict):
@@ -291,7 +289,7 @@ def resource_from_config(resource_from_descriptor):
 
 
 class TestFromConfig(TestDiskResource):
-    expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+    expected_resource_status = ResourceStatus.STANDALONE_NOT_LOADED
 
     @pytest.fixture()
     def dc_resource(self, resource_from_config):
@@ -323,7 +321,7 @@ def zipped_resource_from_fl_package(
 
 
 class TestFromFlPackage(TestDiskResource):
-    expected_resource_status = ResourceStatus.PACKAGED
+    expected_resource_status = ResourceStatus.PACKAGED_NOT_LOADED
     should_have_descriptor = True
 
     @pytest.fixture()
@@ -342,7 +340,7 @@ def zipped_resource_from_dc_package(
 
 
 class TestFromDcPackage(TestDiskResource):
-    expected_resource_status = ResourceStatus.PACKAGED
+    expected_resource_status = ResourceStatus.PACKAGED_NOT_LOADED
     should_have_descriptor = True
 
     @pytest.fixture()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -4,7 +4,7 @@ import frictionless as fl
 import ms3
 import pytest
 from dimcat.dataset import DimcatPackage
-from dimcat.dataset.base import PackageStatus
+from dimcat.dataset.base import Dataset, PackageStatus
 from dimcat.resources.base import DimcatResource, ResourceStatus, get_default_basepath
 
 from tests.conftest import CORPUS_PATH
@@ -501,6 +501,11 @@ class TestDimcatPackage:
         new_object = as_config.create()
         assert new_object == package_obj
 
+    def test_copy(self, package_obj):
+        copy = package_obj.copy()
+        assert copy == package_obj
+        assert copy is not package_obj
+
 
 @pytest.fixture()
 def package_from_descriptor(package_path):
@@ -533,3 +538,11 @@ class TestPackageFromFL(TestPackageFromDescriptor):
 
 
 # endregion test DimcatPackage objects
+
+
+def test_dataset(package_path):
+    dataset = Dataset()
+    dataset.load_package(package_path)
+    new_dataset = Dataset.from_dataset(dataset)
+    assert new_dataset == dataset
+    assert new_dataset is not dataset

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,62 @@
+import os
+
+import frictionless as fl
+import pytest
+from dimcat.base import deserialize_dict
+from dimcat.resources.base import DimcatResource, ResourceStatus
+
+
+class TestResource:
+    @pytest.fixture()
+    def resource_from_descriptor(self, resource_path):
+        resource = DimcatResource(resource=resource_path)
+        return resource
+
+    @pytest.fixture()
+    def resource_schema(self, resource_path):
+        res = fl.Resource(resource_path)
+        return res.schema
+
+    @pytest.fixture()
+    def as_dict(self, resource_from_descriptor):
+        return resource_from_descriptor.to_dict()
+
+    @pytest.fixture()
+    def as_config(self, resource_from_descriptor):
+        return resource_from_descriptor.to_config()
+
+    @pytest.fixture()
+    def resource_dataframe(self, resource_from_descriptor):
+        return resource_from_descriptor.get_dataframe()
+
+    @pytest.fixture()
+    def resource_from_dataframe(self, resource_dataframe, resource_schema):
+        return DimcatResource(df=resource_dataframe, column_schema=resource_schema)
+
+    def test_resource_from_disk(self, resource_from_descriptor):
+        assert resource_from_descriptor.status == ResourceStatus.ON_DISK_NOT_LOADED
+        print(resource_from_descriptor.__dict__)
+        with pytest.raises(RuntimeError):
+            resource_from_descriptor.basepath = "~"
+
+    def test_resource_from_df(self, resource_from_dataframe):
+        print(resource_from_dataframe)
+        assert resource_from_dataframe.status in (
+            ResourceStatus.VALIDATED,
+            ResourceStatus.DATAFRAME,
+        )
+        as_config = resource_from_dataframe.to_config()
+        print(as_config)
+        os.remove(resource_from_dataframe.normpath)
+
+    def test_serialization(self, as_dict, as_config):
+        print(as_dict)
+        print(as_config)
+        assert as_dict == as_config
+
+    def test_deserialization_via_config(self, as_dict, as_config):
+        from_dict = deserialize_dict(as_dict)
+        assert isinstance(from_dict, DimcatResource)
+        from_config = as_config.create()
+        assert isinstance(from_config, DimcatResource)
+        assert from_dict.__dict__.keys() == from_config.__dict__.keys()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -68,6 +68,11 @@ class TestVanillaResource:
     def test_frozen(self, dc_resource):
         assert dc_resource.is_frozen == self.should_be_frozen
 
+    def test_valid(self, dc_resource):
+        report = dc_resource.validate()
+        assert report is None or report.valid
+        assert dc_resource.is_valid
+
 
 @pytest.fixture(scope="session")
 def resource_from_descriptor(resource_path):
@@ -106,6 +111,12 @@ class TestMemoryResource(TestVanillaResource):
     @pytest.fixture()
     def dc_resource(self, empty_resource_with_paths):
         return empty_resource_with_paths
+
+    @pytest.mark.skip(
+        reason="column_schema currently expresses types for reading from disk, not for loaded daata."
+    )
+    def test_valid(self, dc_resource):
+        pass
 
 
 @pytest.fixture(scope="session")
@@ -306,12 +317,6 @@ class TestFromDcPackage(TestDiskResource):
 #     def test_equivalence(self):
 #         assert self.resource_from_descriptor == self.resource_from_fl_resource
 #         assert self.resource_from_descriptor == self.resource_from_dataframe
-#
-#
-#     def test_is_valid(self):
-#         assert self.resource_from_descriptor.is_valid
-#         assert self.resource_from_fl_resource.is_valid
-#         assert not self.resource_from_dataframe.is_valid # currently, schema corresponds to types in TSV not loaded df
 #
 #     def test_is_serialized(self):
 #         assert self.resource_from_descriptor.is_serialized

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -53,6 +53,9 @@ class TestVanillaResource:
     should_be_frozen: bool = False
     """Whether the resource should be frozen, i.e., immutable after initialization."""
     should_be_serialized: bool = False
+    """Whether the resource should figure as serialized after initialization."""
+    should_be_loaded: bool = False
+    """Whether or not we expect the resource to have a dataframe loaded into memory."""
 
     @pytest.fixture()
     def expected_basepath(self):
@@ -81,6 +84,9 @@ class TestVanillaResource:
 
     def test_serialized(self, dc_resource):
         assert dc_resource.is_serialized == self.should_be_serialized
+
+    def test_loaded(self, dc_resource):
+        assert dc_resource.is_loaded == self.should_be_loaded
 
 
 @pytest.fixture(scope="session")
@@ -113,6 +119,8 @@ def empty_resource_with_paths(tmp_serialization_path):
 class TestMemoryResource(TestVanillaResource):
     """MemoryResources are those instantiated from a dataframe. They have in common that, in this
     test suite, their basepath is a temporary path where they can be serialized."""
+
+    should_be_loaded = False  # because this one is empty
 
     @pytest.fixture()
     def expected_basepath(self, tmp_serialization_path):
@@ -158,6 +166,7 @@ def resource_from_dataframe(
 
 class TestFromDataFrame(TestMemoryResource):
     expected_resource_status = ResourceStatus.DATAFRAME
+    should_be_loaded = True
 
     @pytest.fixture()
     def dc_resource(self, resource_from_dataframe) -> DimcatResource:
@@ -178,6 +187,7 @@ def assembled_resource(
 
 class TestAssembledResource(TestMemoryResource):
     expected_resource_status = ResourceStatus.DATAFRAME
+    should_be_loaded = True
 
     @pytest.fixture()
     def dc_resource(self, assembled_resource):
@@ -194,6 +204,7 @@ class TestSerializedResource(TestMemoryResource):
     expected_resource_status = ResourceStatus.ON_DISK_AND_LOADED
     should_be_frozen: bool = True
     should_be_serialized = True
+    should_be_loaded = True
 
     @pytest.fixture()
     def dc_resource(self, serialized_resource):
@@ -329,11 +340,6 @@ class TestFromDcPackage(TestDiskResource):
 #         assert self.resource_from_descriptor == self.resource_from_fl_resource
 #         assert self.resource_from_descriptor == self.resource_from_dataframe
 #
-#
-#     def test_is_loaded(self):
-#         assert not self.resource_from_descriptor.is_loaded
-#         assert not self.resource_from_fl_resource.is_loaded
-#         assert self.resource_from_dataframe.is_loaded
 #
 #     def test_descriptor_path(self):
 #         assert self.resource_from_descriptor.descriptor_path == self.descriptor_path

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -56,6 +56,8 @@ class TestVanillaResource:
     """Whether the resource should figure as serialized after initialization."""
     should_be_loaded: bool = False
     """Whether or not we expect the resource to have a dataframe loaded into memory."""
+    should_have_descriptor: bool = False
+    """Whether or not we expect the resource to have a descriptor file on disk."""
 
     @pytest.fixture()
     def expected_basepath(self):
@@ -88,6 +90,13 @@ class TestVanillaResource:
     def test_loaded(self, dc_resource):
         assert dc_resource.is_loaded == self.should_be_loaded
 
+    def test_descriptor_path(self, dc_resource):
+        descriptor_path = dc_resource.get_descriptor_path(only_if_exists=True)
+        if self.should_have_descriptor:
+            assert descriptor_path is not None
+        else:
+            assert descriptor_path is None
+
 
 @pytest.fixture(scope="session")
 def resource_from_descriptor(resource_path):
@@ -99,6 +108,7 @@ class TestDiskResource(TestVanillaResource):
     expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
     should_be_frozen: bool = True
     should_be_serialized = True
+    should_have_descriptor = True
 
     @pytest.fixture()
     def expected_basepath(self):
@@ -205,6 +215,7 @@ class TestSerializedResource(TestMemoryResource):
     should_be_frozen: bool = True
     should_be_serialized = True
     should_be_loaded = True
+    should_have_descriptor = True
 
     @pytest.fixture()
     def dc_resource(self, serialized_resource):
@@ -219,6 +230,7 @@ def resource_from_fl_resource(fl_resource) -> DimcatResource:
 
 class TestFromFrictionless(TestDiskResource):
     expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+    should_have_descriptor = False
 
     @pytest.fixture()
     def dc_resource(self, resource_from_fl_resource):
@@ -264,6 +276,7 @@ def zipped_resource_from_fl_package(fl_package) -> DimcatResource:
 
 class TestFromFlPackage(TestDiskResource):
     expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+    should_have_descriptor = False
 
     @pytest.fixture()
     def dc_resource(self, zipped_resource_from_fl_package):
@@ -278,6 +291,7 @@ def zipped_resource_from_dc_package(dc_package) -> DimcatResource:
 
 class TestFromDcPackage(TestDiskResource):
     expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+    should_have_descriptor = False
 
     @pytest.fixture()
     def dc_resource(self, zipped_resource_from_dc_package):
@@ -339,12 +353,6 @@ class TestFromDcPackage(TestDiskResource):
 #     def test_equivalence(self):
 #         assert self.resource_from_descriptor == self.resource_from_fl_resource
 #         assert self.resource_from_descriptor == self.resource_from_dataframe
-#
-#
-#     def test_descriptor_path(self):
-#         assert self.resource_from_descriptor.descriptor_path == self.descriptor_path
-#         assert self.resource_from_fl_resource.descriptor_path is None
-#         assert self.resource_from_dataframe.descriptor_path is None
 #
 #     def test_basepath(self):
 #         assert self.resource_from_descriptor.basepath == os.path.dirname(self.descriptor_path)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -171,6 +171,7 @@ def resource_from_dataframe(
         resource_name=fl_resource.name,
         basepath=tmp_serialization_path,
         column_schema=fl_resource.schema,
+        auto_validate=False,
     )
 
 
@@ -188,7 +189,9 @@ def assembled_resource(
     dataframe_from_tsv, fl_resource, tmp_serialization_path
 ) -> DimcatResource:
     resource = DimcatResource(
-        resource_name=fl_resource.name, column_schema=fl_resource.schema
+        resource_name=fl_resource.name,
+        column_schema=fl_resource.schema,
+        auto_validate=False,
     )
     resource.df = dataframe_from_tsv
     resource.basepath = tmp_serialization_path

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -45,6 +45,8 @@ def empty_resource():
 class TestVanillaResource:
     expected_resource_status: ResourceStatus = ResourceStatus.EMPTY
     """The expected status of the resource after initialization."""
+    should_be_frozen: bool = False
+    """Whether the resource should be frozen, i.e., immutable after initialization."""
 
     @pytest.fixture()
     def expected_basepath(self):
@@ -63,6 +65,9 @@ class TestVanillaResource:
     def test_status_after_init(self, dc_resource):
         assert dc_resource.status == self.expected_resource_status
 
+    def test_frozen(self, dc_resource):
+        assert dc_resource.is_frozen == self.should_be_frozen
+
 
 @pytest.fixture(scope="session")
 def resource_from_descriptor(resource_path):
@@ -72,6 +77,7 @@ def resource_from_descriptor(resource_path):
 
 class TestDiskResource(TestVanillaResource):
     expected_resource_status = ResourceStatus.ON_DISK_NOT_LOADED
+    should_be_frozen: bool = True
 
     @pytest.fixture()
     def expected_basepath(self):
@@ -90,6 +96,9 @@ def empty_resource_with_paths(tmp_serialization_path):
 
 
 class TestMemoryResource(TestVanillaResource):
+    """MemoryResources are those instantiated from a dataframe. They have in common that, in this
+    test suite, their basepath is a temporary path where they can be serialized."""
+
     @pytest.fixture()
     def expected_basepath(self, tmp_serialization_path):
         return tmp_serialization_path
@@ -162,6 +171,7 @@ def serialized_resource(resource_from_dataframe) -> DimcatResource:
 
 class TestSerializedResource(TestMemoryResource):
     expected_resource_status = ResourceStatus.ON_DISK_AND_LOADED
+    should_be_frozen: bool = True
 
     @pytest.fixture()
     def dc_resource(self, serialized_resource):
@@ -297,11 +307,6 @@ class TestFromDcPackage(TestDiskResource):
 #         assert self.resource_from_descriptor == self.resource_from_fl_resource
 #         assert self.resource_from_descriptor == self.resource_from_dataframe
 #
-
-#     def test_is_frozen(self):
-#         assert self.resource_from_descriptor.is_frozen
-#         assert self.resource_from_fl_resource.is_frozen
-#         assert not self.resource_from_dataframe.is_frozen
 #
 #     def test_is_valid(self):
 #         assert self.resource_from_descriptor.is_valid


### PR DESCRIPTION
The most intricate object, here, is the `DimcatResource` which wraps a `frictionless.Resource` object and loads the described dataframe into memory only on demand. It is intricate because there is quite a range of cases to cover including those where a DimcatResource is created from scratch, with dataframe, schema, and `.json` descriptor file on disk added individually later, each potentially changing the behaviour (e.g. to `is_frozen` once descriptor is stored to disk) or validation status (e.g. when changing the `frictionless.Schema`).

This PR also adds `metadata` to some of the Schema fields and improves the `mwe.py` minimal working example.