### PR TITLE
Metacorpus submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "docs/notebooks"]
 	path = docs/notebooks
 	url = https://github.com/DCMLab/data_reports.git
+[submodule "unittest_metacorpus"]
+	path = unittest_metacorpus
+	url = https://github.com/DCMLab/unittest_metacorpus

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from git import Repo
 
 # ----------------------------- SETTINGS -----------------------------
 # Directory holding your clone of github.com/DCMLab/unittest_metacorpus
-CORPUS_DIR = "~"
+CORPUS_DIR = os.path.abspath("..")
 
 # region test directories and files
 


### PR DESCRIPTION
This adds `unittest_metacorpus` as a submodule pinned to the current test commit and has the unittests use it.

Maybe to be merged into #13 @huguesdevimeux ?