### PR TITLE
Makes pandas be installed via pip instead of deps in tox.ini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Install tox
         run: pip install tox
       - name: Run tests
-        # As of now, running tox wirthout environment simplmy runs tests with the test matrix defined in
+        # As of now, running tox without environment runs the tests w.r.t the test matrix defined in
         # tox.ini.
         run: tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ["3.10"]
 
     steps:
       - uses: actions/checkout@v3
@@ -19,7 +16,9 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
+          python-version: |
+            3.10
+            3.11
       - name: Install tox
         run: pip install tox
       - name: Run tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,21 +5,19 @@
 minversion = 4.4.5
 isolated_build = True
 # Matrix of test used to test
-env_list = spython{3.11,3.10}-pd{1.5,2}
+env_list = py{311,310}-pd{1.5,2}
 requires =
     tox>=4
+skip_install = True
 
 [testenv]
 description = Invoke pytest to run automated tests
 package = wheel
 wheel_build_env = .pkg
 extras = testing
-deps =
-    pd1.5: pandas<2
-    pd2: pandas>=2
 commands =
+    pd2: pip install 'pandas>=2'
     pytest {tty:--color=yes} {posargs}
-
 
 [testenv:commit]
 description = run the pre-commit hook configured via .pre-commit-config.yaml


### PR DESCRIPTION
Fixes #48

Also includes a fix : nowpython 3.11 is installed in the github workflow, so tox does not skip test envs with python 3.11