### PR TITLE
Fixed github actions unproperly run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,11 @@ name: Run tests
 
 on:
   push:
+    branches:
+      - development
   pull_request:
-    types: [opened]
+    branches:
+      - development
 
 jobs:
   test:

--- a/README.rst
+++ b/README.rst
@@ -33,20 +33,22 @@
 |
 
 ======
-dimcat
+DiMCAT
 ======
 
 
     DIgital Musicology Corpus Analysis Toolkit
 
 
-Library and commandline tool for analyzing symbolic music corpora.
+Library and commandline tool for for processing and analyzing notated music on a very large scale
 
 
-.. _pyscaffold-notes:
+Acknowledgements
+================
 
-Note
-====
+Development of this software tool was supported by the Swiss National Science Foundation within the
+project “Distant Listening – The Development of Harmony over Three Centuries (1700–2000)”
+(Grant no. 182811). This project is being conducted at the Latour Chair in Digital and Cognitive
+Musicology, generously funded by Mr. Claude Latour.
 
-This project has been set up using PyScaffold 4.2.1. For details and usage
-information on PyScaffold see https://pyscaffold.org/.
+The software project has been set up using PyScaffold 4.2.1.

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ isolated_build = True
 env_list = py{311,310}-pd{1.5,2}
 requires =
     tox>=4
-skip_install = True
 
 [testenv]
 description = Invoke pytest to run automated tests


### PR DESCRIPTION
Fixes #51 

Includes a removal of `skip_install` line in tox.ini. This is a minor change that does not have any consequence, as `skip_install` cannot be in `[tox]` section anyway (so, it was getting ignored). 

